### PR TITLE
Improvement: maven actions: override invocations

### DIFF
--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -47,13 +47,13 @@ jobs:
     steps:
       # The create-app-vars-matrix action requires source code to be available
       - name: 🧹 Clean workspace
-        uses: dsb-norge/github-actions/directory-recreate@v1
+        uses: dsb-norge/github-actions/directory-recreate@v1.5
       - name: ⬇ Checkout working branch
         uses: actions/checkout@v2
 
       - name: 🎰 Create app vars build matrix
         id: create-matrix
-        uses: dsb-norge/github-actions/ci-cd/create-app-vars-matrix@v1
+        uses: dsb-norge/github-actions/ci-cd/create-app-vars-matrix@v1.5
         with:
           apps: ${{ inputs.apps }}
 
@@ -71,14 +71,14 @@ jobs:
 
     steps:
       - name: 🧹 Clean workspace
-        uses: dsb-norge/github-actions/directory-recreate@v1
+        uses: dsb-norge/github-actions/directory-recreate@v1.5
 
       - name: ⬇ Checkout working branch
         uses: actions/checkout@v2
 
       - name: 🎰 Generate DSB build variables
         id: build-env
-        uses: dsb-norge/github-actions/ci-cd/create-build-envs@v1
+        uses: dsb-norge/github-actions/ci-cd/create-build-envs@v1.5
         with:
           app-vars: ${{ toJSON(matrix.app-vars) }}
           maven-repo-username: ${{ secrets.maven-repo-username }}
@@ -97,7 +97,7 @@ jobs:
         if: |
           ! ( github.event_name == 'pull_request' && github.event.action == 'closed' )
           && matrix.app-vars.application-type == 'spring-boot'
-        uses: dsb-norge/github-actions/ci-cd/build-maven-project@v1
+        uses: dsb-norge/github-actions/ci-cd/build-maven-project@v1.5
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
@@ -106,7 +106,7 @@ jobs:
         if: |
           ! ( github.event_name == 'pull_request' && github.event.action == 'closed' )
           && matrix.app-vars.application-type == 'spring-boot'
-        uses: dsb-norge/github-actions/ci-cd/build-spring-boot-image@v1
+        uses: dsb-norge/github-actions/ci-cd/build-spring-boot-image@v1.5
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
@@ -115,7 +115,7 @@ jobs:
         if: |
           ! ( github.event_name == 'pull_request' && github.event.action == 'closed' )
           && matrix.app-vars.application-type == 'vue'
-        uses: dsb-norge/github-actions/ci-cd/build-nodejs-project@v1
+        uses: dsb-norge/github-actions/ci-cd/build-nodejs-project@v1.5
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
@@ -124,14 +124,14 @@ jobs:
         if: |
           ! ( github.event_name == 'pull_request' && github.event.action == 'closed' )
           && matrix.app-vars.application-type == 'vue'
-        uses: dsb-norge/github-actions/ci-cd/build-docker-image@v1
+        uses: dsb-norge/github-actions/ci-cd/build-docker-image@v1.5
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
       - name: 🐙 Deploy to ephemeral PR environment
         # Skip step when closing a PR and when building main
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
-        uses: dsb-norge/github-actions/ci-cd/deploy-to-ephemeral@v1
+        uses: dsb-norge/github-actions/ci-cd/deploy-to-ephemeral@v1.5
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
@@ -140,14 +140,14 @@ jobs:
         if: |
           github.ref == 'refs/heads/main' &&
           ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' )
-        uses: dsb-norge/github-actions/ci-cd/deploy-to-static@v1
+        uses: dsb-norge/github-actions/ci-cd/deploy-to-static@v1.5
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
       - name: 🗑 Teardown of ephemeral PR environment
         # Step only runs when closing a PR
         if: github.event_name == 'pull_request' && github.event.action == 'closed'
-        uses: dsb-norge/github-actions/ci-cd/teardown-pr-environment@v1
+        uses: dsb-norge/github-actions/ci-cd/teardown-pr-environment@v1.5
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
@@ -155,13 +155,13 @@ jobs:
         # Skip step when closing a PR
         if: |
           ! ( github.event_name == 'pull_request' && github.event.action == 'closed' )
-        uses: dsb-norge/github-actions/ci-cd/prune-images-from-acr@v1
+        uses: dsb-norge/github-actions/ci-cd/prune-images-from-acr@v1.5
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
       - name: 🗑 Delete PR docker images from ACR
         # Step only runs when closing a PR
         if: github.event_name == 'pull_request' && github.event.action == 'closed'
-        uses: dsb-norge/github-actions/ci-cd/delete-pr-images-from-acr@v1
+        uses: dsb-norge/github-actions/ci-cd/delete-pr-images-from-acr@v1.5
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}

--- a/ci-cd/build-docker-image/action.yml
+++ b/ci-cd/build-docker-image/action.yml
@@ -11,7 +11,7 @@ runs:
   using: 'composite'
   steps:
     # verify we have required inputs in order to avoid blank labels/tags
-    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1
+    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1.5
       with:
         dsb-build-envs: ${{ inputs.dsb-build-envs }}
         require: |
@@ -26,7 +26,7 @@ runs:
           application-source-path
 
     # log into azure container registry (ACR)
-    - uses: azure/docker-login@v1
+    - uses: azure/docker-login@v1.5
       with:
         login-server: ${{ fromJSON(inputs.dsb-build-envs).docker-image-registry }}
         username: ${{ fromJSON(inputs.dsb-build-envs).acr-username }}

--- a/ci-cd/build-maven-project/action.yml
+++ b/ci-cd/build-maven-project/action.yml
@@ -3,21 +3,47 @@ description: |
   Given the required input this action configures the specified version of java and builds a given maven project.
   Before maven is invoked the version and distribution of JDK specified in 'dsb-build-envs' is installed.
   The maven invocation consists of two parts:
-    - Part one: set maven project version using the goal 'versions:set' and version from input 'dsb-build-envs.application-version'
-    - Part two: invoke maven with goals specified in 'mvn-goals' input.
-  In both cases arguments to maven are passed from the input 'mvn-args'.
-  As for pom file the field 'application-source-path' of 'dsb-build-envs' can point either to an existing pom.xml or to a directory containing it.
-  If the pom.xml is not found this action will fail.
+    - Part one: set maven project version to input 'dsb-build-envs.application-version'.
+    - Part two: invoke maven for build (see goals and arguments below).
+  Common inputs:
+    'set-extra-envs' accepts a JSON object with extra environment variables to set in same scope as maven is invoked, prior to invocation.
+  First part inputs:
+    The version used in this invocation is controlled by 'application-version' defined in 'dsb-build-envs'.
+    The final argument of the maven invocation in this part, defining the version number, is hardcoded. Ie. all invocations will have
+    the following argument prepended: '-DnewVersion=<version>'
+    If the 'mvn-version-cmd' input is set this will be used (replaces the whole maven invocation command).
+    If the 'mvn-version-cmd' input is empty:
+      - And 'maven-build-project-version-command' is defined in 'dsb-build-envs', this will be used (replaces the whole maven
+        invocation command).
+      - And 'maven-build-project-version-command' is NOT defined in 'dsb-build-envs':
+        - And 'maven-build-project-version-goals' is defined in 'dsb-build-envs', goals from 'maven-build-project-version-goals' will
+          be used. Otherwise default goal will be used: 'versions:set'.
+        - And 'maven-build-project-version-arguments' is defined in 'dsb-build-envs', arguments from
+          'maven-build-project-version-arguments' will be used. Otherwise default argument will be used: '-B'.
+        - The pom file used will be the one defined by 'application-source-path' in 'dsb-build-envs', can point either to an existing
+          pom.xml or to a directory containing it.
+        - The resulting maven invocation command is: mvn <arguments> --file <pom file> <goals>
+  Second part inputs:
+    If the 'mvn-cmd' input is set this will be used (replaces the whole maven invocation command).
+    If the 'mvn-cmd' input is empty:
+      - And 'maven-build-project-command' is defined in 'dsb-build-envs', this will be used (replaces the whole maven invocation command).
+      - And 'maven-build-project-command' is NOT defined in 'dsb-build-envs':
+        - And 'maven-build-project-goals' is defined in 'dsb-build-envs', goals from 'maven-build-project-goals' will be used. Otherwise
+          default goals will be used: 'clean verify install org.sonarsource.scanner.maven:sonar-maven-plugin:sonar'.
+        - And 'maven-build-project-arguments' is defined in 'dsb-build-envs', arguments from 'maven-build-project-arguments' will be used.
+          Otherwise default argument will be used: '-B'.
+        - The pom file used will be the one defined by 'application-source-path' in 'dsb-build-envs', can point either to an existing pom.xml or to a directory containing it.
+        - The resulting maven invocation command is: mvn <arguments> --file <pom file> <goals>
 author: 'Peder Schmedling'
 inputs:
-  mvn-goals:
-    description: 'Goals specified to Maven.'
+  mvn-version-cmd:
+    description: 'Override command string used when invoking maven in the first part.'
     required: false
-    default: 'clean verify install org.sonarsource.scanner.maven:sonar-maven-plugin:sonar'
-  mvn-args:
-    description: 'Arguments passed to Maven.'
+    default: ''
+  mvn-cmd:
+    description: 'Override command string used when invoking maven in the second part.'
     required: false
-    default: '-B' # -B = batch-mode
+    default: ''
   set-extra-envs:
     description: 'JSON object with extra environment variables to set in same scope as maven is invoked.'
     required: false
@@ -25,26 +51,111 @@ inputs:
   dsb-build-envs:
     description: 'DSB build environment variables JSON.'
     required: true
+
 runs:
   using: 'composite'
   steps:
-    # define envs
+    # verify we have required inputs in order to avoid blank labels/tags
+    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1.5
+      with:
+        dsb-build-envs: ${{ inputs.dsb-build-envs }}
+        require: |
+          application-source-path
+          application-version
+          java-distribution
+          java-version
+          maven-repo-pom-id
+          jasypt-password
+          github-repo-token
+          sonarqube-token
+          maven-repo-token
+          maven-repo-username
+
+    # locate pom.xml and define maven commands
     - id: mvn-cmd
       shell: bash
       run: |
         # Locate pom.xml and define maven commands
 
+        # Defaults
+        MVN_VERSION_ARGUMENTS_DEFAULT='-B'
+        MVN_VERSION_GOALS_DEFAULT='versions:set'
+        MVN_ARGUMENTS_DEFAULT='-B'
+        MVN_GOALS_DEFAULT='clean verify install org.sonarsource.scanner.maven:sonar-maven-plugin:sonar'
+
+        BUILD_ENVS=$(cat <<'EOF'
+        ${{ inputs.dsb-build-envs }}
+        EOF
+        )
+
+        # Helper functions
+        # Check if field exists in BUILD_ENVS safely
+        function has-field { if [[ "$(echo "${BUILD_ENVS}"| jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
+        # Get field value from BUILD_ENVS safely
+        function get-val { echo "${BUILD_ENVS}" | jq -r --arg name "$1" '.[$name]'; }
+
+        # Locate pom.xml
         POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}"
         [ ! -f "${POM_FILE}" ] && POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}/pom.xml"
         [ ! -f "${POM_FILE}" ] && \
           echo "ERROR: build-dsb-maven-project: Cannot find pom.xml. Both '${{ fromJSON(inputs.dsb-build-envs).application-source-path }}' and '${POM_FILE}' does not exist!" && \
           exit 1
 
-        MVN_VERSION_CMD="mvn ${{ inputs.mvn-args }} --file ${POM_FILE} versions:set -DnewVersion=${{ fromJSON(inputs.dsb-build-envs).application-version }}"
-        echo "build-dsb-maven-project: Maven version command: '${MVN_VERSION_CMD}'"
+        # Determine maven command for first invocation
+        echo "::group::build-dsb-maven-project: maven version command"
+        if [ ! -z '${{ inputs.mvn-version-cmd }}' ]; then
+          echo "build-dsb-maven-project: using maven version command from 'inputs.mvn-version-cmd'."
+          MVN_VERSION_CMD='${{ inputs.mvn-version-cmd }} -DnewVersion=${{ fromJSON(inputs.dsb-build-envs).application-version }}'
+        elif has-field 'maven-build-project-version-command'; then
+          echo "build-dsb-maven-project: using maven version command from 'inputs.dsb-build-envs.maven-build-project-version-command'."
+          MVN_VERSION_CMD="$(get-val 'maven-build-project-version-command') -DnewVersion=${{ fromJSON(inputs.dsb-build-envs).application-version }}"
+        else
+          if has-field 'maven-build-project-version-goals'; then
+            echo "build-dsb-maven-project: using maven version goals from 'inputs.dsb-build-envs.maven-build-project-version-goals'."
+            MVN_VERSION_GOALS="$(get-val 'maven-build-project-version-goals')"
+          else
+            echo "build-dsb-maven-project: using default maven version goals."
+            MVN_VERSION_GOALS="${MVN_VERSION_GOALS_DEFAULT}"
+          fi
+          if has-field 'maven-build-project-version-arguments'; then
+            echo "build-dsb-maven-project: using maven version arguments from 'inputs.dsb-build-envs.maven-build-project-version-arguments'."
+            MVN_VERSION_ARGUMENTS="$(get-val 'maven-build-project-version-arguments')"
+          else
+            echo "build-dsb-maven-project: using default maven version arguments."
+            MVN_VERSION_ARGUMENTS="${MVN_VERSION_ARGUMENTS_DEFAULT}"
+          fi
+          MVN_VERSION_CMD="mvn ${MVN_VERSION_ARGUMENTS} --file ${POM_FILE} ${MVN_VERSION_GOALS} -DnewVersion=${{ fromJSON(inputs.dsb-build-envs).application-version }}"
+        fi
+        echo "::endgroup::"
+        echo "build-dsb-maven-project: maven version command: '${MVN_VERSION_CMD}'"
         echo "::set-output name=mvn-version-cmd::${MVN_VERSION_CMD}"
 
-        MVN_CMD="mvn ${{ inputs.mvn-args }} --file ${POM_FILE} ${{ inputs.mvn-goals }}"
+        # Determine maven command for second invocation
+        echo "::group::build-dsb-maven-project: maven command"
+        if [ ! -z '${{ inputs.mvn-cmd }}' ]; then
+          echo "build-dsb-maven-project: using maven command from 'inputs.mvn-cmd'."
+          MVN_CMD='${{ inputs.mvn-cmd }}'
+        elif has-field 'maven-build-project-command'; then
+          echo "build-dsb-maven-project: using maven command from 'inputs.dsb-build-envs.maven-build-project-command'."
+          MVN_CMD="$(get-val 'maven-build-project-command')"
+        else
+          if has-field 'maven-build-project-goals'; then
+            echo "build-dsb-maven-project: using maven goals from 'inputs.dsb-build-envs.maven-build-project-goals'."
+            MVN_GOALS="$(get-val 'maven-build-project-goals')"
+          else
+            echo "build-dsb-maven-project: using default maven goals."
+            MVN_GOALS="${MVN_GOALS_DEFAULT}"
+          fi
+          if has-field 'maven-build-project-arguments'; then
+            echo "build-dsb-maven-project: using maven arguments from 'inputs.dsb-build-envs.maven-build-project-arguments'."
+            MVN_ARGUMENTS="$(get-val 'maven-build-project-arguments')"
+          else
+            echo "build-dsb-maven-project: using default maven arguments."
+            MVN_ARGUMENTS="${MVN_ARGUMENTS_DEFAULT}"
+          fi
+          MVN_CMD="mvn ${MVN_ARGUMENTS} --file ${POM_FILE} ${MVN_GOALS}"
+        fi
+        echo "::endgroup::"
         echo "build-dsb-maven-project: Maven build command: '${MVN_CMD}'"
         echo "::set-output name=mvn-cmd::${MVN_CMD}"
 
@@ -59,7 +170,7 @@ runs:
         server-password: DSB_MAVEN_REPO_TOKEN
         overwrite-settings: true
 
-    #  Invoke maven
+    # invoke maven
     - shell: bash
       run: |
         # Define extra envs, if any, and invoke maven
@@ -68,8 +179,7 @@ runs:
         ${{ inputs.set-extra-envs }}
         EOF
         )
-        if [ ! -z "$EXTRA_ENVS" ];
-        then
+        if [ ! -z "$EXTRA_ENVS" ]; then
           echo "::group::build-dsb-maven-project: extra environment variables"
           JSON_FIELDS=$(echo ${EXTRA_ENVS} | jq -r '[keys[]] | join(" ")')
           for JSON_FIELD in ${JSON_FIELDS}; do
@@ -87,7 +197,6 @@ runs:
 
         echo "::group::build-dsb-maven-project: Invoke maven with goals"
         echo "build-dsb-maven-project: command string: '${{ steps.mvn-cmd.outputs.mvn-cmd }}'"
-        echo '${{ inputs.mvn-goals }}'
         ${{ steps.mvn-cmd.outputs.mvn-cmd }}
         echo "::endgroup::"
       env:

--- a/ci-cd/build-nodejs-project/action.yml
+++ b/ci-cd/build-nodejs-project/action.yml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     # set up Node.js
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v1.5
       with:
         node-version:  ${{ fromJSON(inputs.dsb-build-envs).nodejs-version }}
 

--- a/ci-cd/build-spring-boot-image/action.yml
+++ b/ci-cd/build-spring-boot-image/action.yml
@@ -1,6 +1,33 @@
 name: 'Build spring boot OCI image with labels and tags'
 description: |
   Use spring boot maven plugin to build OCI image from maven project.
+  This uses the action dsb-norge/github-actions/ci-cd/build-maven-project to invoke maven.
+  Default maven invocations are:
+    1. mvn -B --file <pom file> versions:set -DnewVersion=<version>
+    2. mvn -B -DskipTests -Dspring-boot.build-image.imageName=local-spring-boot-image:v0 --file <pom file> spring-boot:build-image
+    - Where <pom file> is defined by 'application-source-path' in 'dsb-build-envs', can point either to an existing pom.xml or to a directory containing it.
+    - Where <version> is controlled by 'application-version' defined in 'dsb-build-envs'.
+  Maven invocations can be overriden:
+    Note before overriding:
+      - Make sure that the local OCI image built by the maven invocation is tagged as 'local-spring-boot-image:v0'. Failure to fullfill this will result
+        in the tagging and pushing step of this action to fail.
+    Invocation #1:
+      - If 'spring-boot-build-image-version-command' is defined in 'dsb-build-envs', this will be used (replaces the whole maven invocation command).
+        With the exception that the version number is hardcoded. Ie. all invocations will have the following argument prepended: '-DnewVersion=<version>'
+      - If 'spring-boot-build-image-version-command' is NOT defined in 'dsb-build-envs':
+        - And 'spring-boot-build-image-version-goals' is defined in 'dsb-build-envs', goals from 'spring-boot-build-image-version-goals' will be used.
+        - And 'spring-boot-build-image-version-arguments' is defined in 'dsb-build-envs', arguments from
+          'spring-boot-build-image-version-arguments' will be used.
+        - When specific goals and/or arguments are defined the pom file reference will still be added to the final maven invocation. The resulting
+          maven invocation command is: mvn <arguments> --file <pom file> <goals>
+    Invocation #2 - Similar logic as #1 without <version> and different fields of 'dsb-build-envs':
+      - If 'spring-boot-build-image-command' is defined in 'dsb-build-envs', this will be used (replaces the whole maven invocation command).
+      - If 'spring-boot-build-image-command' is NOT defined in 'dsb-build-envs':
+        - And 'spring-boot-build-image-goals' is defined in 'dsb-build-envs', goals from 'spring-boot-build-image-version-goals' will be used.
+        - And 'spring-boot-build-image-arguments' is defined in 'dsb-build-envs', arguments from
+          'spring-boot-build-image-arguments' will be used.
+        - When specific goals and/or arguments are defined the pom file reference will still be added to the final maven invocation. The resulting
+          maven invocation command is: mvn <arguments> --file <pom file> <goals>
 author: 'Peder Schmedling'
 inputs:
   dsb-build-envs:
@@ -10,7 +37,7 @@ runs:
   using: 'composite'
   steps:
     # verify we have required inputs in order to avoid blank labels/tags
-    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1
+    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1.5
       with:
         dsb-build-envs: ${{ inputs.dsb-build-envs }}
         require: |
@@ -22,9 +49,13 @@ runs:
           application-build-timestamp
           application-source
           application-source-revision
+          application-source-path
+          docker-image-registry
+          acr-username
+          acr-password
 
     # log into azure container registry (ACR)
-    - uses: azure/docker-login@v1
+    - uses: azure/docker-login@v1.5
       with:
         login-server: ${{ fromJSON(inputs.dsb-build-envs).docker-image-registry }}
         username: ${{ fromJSON(inputs.dsb-build-envs).acr-username }}
@@ -108,11 +139,93 @@ runs:
         OUT_JSON_ESC=$(escape-for-output "${OUT_JSON}")
         echo "::set-output name=json::${OUT_JSON_ESC}"
 
+    # define maven commands
+    - id: mvn-cmd
+      shell: bash
+      run: |
+        # Define maven commands
+
+        # Defaults
+        MVN_VERSION_ARGUMENTS_DEFAULT='-B'
+        MVN_VERSION_GOALS_DEFAULT='versions:set'
+        MVN_ARGUMENTS_DEFAULT='-B -DskipTests -Dspring-boot.build-image.imageName=local-spring-boot-image:v0'
+        MVN_GOALS_DEFAULT='spring-boot:build-image'
+
+        BUILD_ENVS=$(cat <<'EOF'
+        ${{ inputs.dsb-build-envs }}
+        EOF
+        )
+
+        # Helper functions
+        # Check if field exists in BUILD_ENVS safely
+        function has-field { if [[ "$(echo "${BUILD_ENVS}"| jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
+        # Get field value from BUILD_ENVS safely
+        function get-val { echo "${BUILD_ENVS}" | jq -r --arg name "$1" '.[$name]'; }
+
+        # Locate pom.xml
+        POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}"
+        [ ! -f "${POM_FILE}" ] && POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}/pom.xml"
+        [ ! -f "${POM_FILE}" ] && \
+          echo "ERROR: build-spring-boot-image: Cannot find pom.xml. Both '${{ fromJSON(inputs.dsb-build-envs).application-source-path }}' and '${POM_FILE}' does not exist!" && \
+          exit 1
+
+        # Determine maven command for first invocation
+        echo "::group::build-spring-boot-image: maven version command"
+        if has-field 'spring-boot-build-image-version-command'; then
+          echo "build-spring-boot-image: using maven version command from 'inputs.dsb-build-envs.spring-boot-build-image-version-command'."
+          MVN_VERSION_CMD="$(get-val 'spring-boot-build-image-version-command')"
+        else
+          if has-field 'spring-boot-build-image-version-goals'; then
+            echo "build-spring-boot-image: using maven version goals from 'inputs.dsb-build-envs.spring-boot-build-image-version-goals'."
+            MVN_VERSION_GOALS="$(get-val 'spring-boot-build-image-version-goals')"
+          else
+            echo "build-spring-boot-image: using default maven version goals."
+            MVN_VERSION_GOALS="${MVN_VERSION_GOALS_DEFAULT}"
+          fi
+          if has-field 'spring-boot-build-image-version-arguments'; then
+            echo "build-spring-boot-image: using maven version arguments from 'inputs.dsb-build-envs.spring-boot-build-image-version-arguments'."
+            MVN_VERSION_ARGUMENTS="$(get-val 'spring-boot-build-image-version-arguments')"
+          else
+            echo "build-spring-boot-image: using default maven version arguments."
+            MVN_VERSION_ARGUMENTS="${MVN_VERSION_ARGUMENTS_DEFAULT}"
+          fi
+          MVN_VERSION_CMD="mvn ${MVN_VERSION_ARGUMENTS} --file ${POM_FILE} ${MVN_VERSION_GOALS}"
+        fi
+        echo "::endgroup::"
+        echo "build-spring-boot-image: maven version command: '${MVN_VERSION_CMD}'"
+        echo "::set-output name=mvn-version-cmd::${MVN_VERSION_CMD}"
+
+        # Determine maven command for second invocation
+        echo "::group::build-spring-boot-image: maven command"
+        if has-field 'spring-boot-build-image-command'; then
+          echo "build-spring-boot-image: using maven command from 'inputs.dsb-build-envs.spring-boot-build-image-command'."
+          MVN_CMD="$(get-val 'spring-boot-build-image-command')"
+        else
+          if has-field 'spring-boot-build-image-goals'; then
+            echo "build-spring-boot-image: using maven goals from 'inputs.dsb-build-envs.spring-boot-build-image-goals'."
+            MVN_GOALS="$(get-val 'spring-boot-build-image-goals')"
+          else
+            echo "build-spring-boot-image: using default maven goals."
+            MVN_GOALS="${MVN_GOALS_DEFAULT}"
+          fi
+          if has-field 'spring-boot-build-image-arguments'; then
+            echo "build-spring-boot-image: using maven arguments from 'inputs.dsb-build-envs.spring-boot-build-image-arguments'."
+            MVN_ARGUMENTS="$(get-val 'spring-boot-build-image-arguments')"
+          else
+            echo "build-spring-boot-image: using default maven arguments."
+            MVN_ARGUMENTS="${MVN_ARGUMENTS_DEFAULT}"
+          fi
+          MVN_CMD="mvn ${MVN_ARGUMENTS} --file ${POM_FILE} ${MVN_GOALS}"
+        fi
+        echo "::endgroup::"
+        echo "build-spring-boot-image: Maven build command: '${MVN_CMD}'"
+        echo "::set-output name=mvn-cmd::${MVN_CMD}"
+
     # build docker image
-    - uses: dsb-norge/github-actions/ci-cd/build-maven-project@v1
+    - uses: dsb-norge/github-actions/ci-cd/build-maven-project@v1.5
       with:
-        mvn-goals: spring-boot:build-image
-        mvn-args: -B -DskipTests -Dspring-boot.build-image.imageName=local-spring-boot-image:v0
+        mvn-version-cmd: ${{ steps.mvn-cmd.outputs.mvn-version-cmd }}
+        mvn-cmd: ${{ steps.mvn-cmd.outputs.mvn-cmd }}
         set-extra-envs: ${{ steps.extra-envs.outputs.json }}
         dsb-build-envs: ${{ inputs.dsb-build-envs }}
 

--- a/ci-cd/delete-pr-images-from-acr/action.yml
+++ b/ci-cd/delete-pr-images-from-acr/action.yml
@@ -19,7 +19,7 @@ runs:
         exit ${EXIT_CODE}
 
     # we need to verify inputs since they are optional input to create-build-envs action
-    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1
+    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1.5
       with:
         dsb-build-envs: ${{ inputs.dsb-build-envs }}
         require: |
@@ -29,7 +29,7 @@ runs:
           application-image-name
 
     # log into Azure CLI with service principal
-    - uses: azure/login@v1
+    - uses: azure/login@v1.5
       with:
         creds: ${{ fromJSON(inputs.dsb-build-envs).acr-service-principal }}
         allow-no-subscriptions: true

--- a/ci-cd/deploy-to-ephemeral/action.yml
+++ b/ci-cd/deploy-to-ephemeral/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'composite'
   steps:
     # we need to verify inputs since they are optional input to create-build-envs action
-    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1
+    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1.5
       with:
         dsb-build-envs: ${{ inputs.dsb-build-envs }}
         require: |
@@ -87,7 +87,7 @@ runs:
         fi
 
     # set target kubernetes cluster to
-    - uses: Azure/aks-set-context@v1
+    - uses: Azure/aks-set-context@v1.5
       with:
         creds: ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-aks-creds }}
         cluster-name: ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-aks-cluster-name }}

--- a/ci-cd/deploy-to-static/action.yml
+++ b/ci-cd/deploy-to-static/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'composite'
   steps:
     # we need to verify inputs since they are optional input to create-build-envs action
-    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1
+    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1.5
       with:
         dsb-build-envs: ${{ inputs.dsb-build-envs }}
         require: |

--- a/ci-cd/prune-images-from-acr/action.yml
+++ b/ci-cd/prune-images-from-acr/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     # we need to verify inputs since they are optional input to create-build-envs action
-    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1
+    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1.5
       with:
         dsb-build-envs: ${{ inputs.dsb-build-envs }}
         require: |
@@ -22,7 +22,7 @@ runs:
           docker-image-prune-keep-num-days
 
     # log into Azure CLI with service principal
-    - uses: azure/login@v1
+    - uses: azure/login@v1.5
       with:
         creds: ${{ fromJSON(inputs.dsb-build-envs).acr-service-principal }}
         allow-no-subscriptions: true

--- a/ci-cd/teardown-pr-environment/action.yml
+++ b/ci-cd/teardown-pr-environment/action.yml
@@ -19,7 +19,7 @@ runs:
         exit ${EXIT_CODE}
 
     # we need to verify inputs since they are optional input to create-build-envs action
-    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1
+    - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1.5
       with:
         dsb-build-envs: ${{ inputs.dsb-build-envs }}
         require: |
@@ -30,7 +30,7 @@ runs:
           pr-deploy-k8s-application-name
 
     # set target k8s cluster
-    - uses: Azure/aks-set-context@v1
+    - uses: Azure/aks-set-context@v1.5
       with:
         creds: ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-aks-creds }}
         cluster-name: ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-aks-cluster-name }}


### PR DESCRIPTION
# Improvements
- Action `build-maven-project`:
  - Added the possibility to override the maven invocations with inputs `mvn-version-cmd` and `mvn-cmd`.
  - Added the possibility to override the maven invocations with inputs `dsb-build-envs.maven-build-project-version-command` and `dsb-build-envs.maven-build-project-command`.
  - Added the possibility to override the maven arguments with the inputs `dsb-build-envs.maven-build-project-version-arguments` and `dsb-build-envs.maven-build-project-arguments`.
  - Added the possibility to override the maven goals with the inputs `dsb-build-envs.maven-build-project-version-goals` and `dsb-build-envs.maven-build-project-goals`.
  - Removed support for inputs `mvn-goals` and `mvn-args`.
- Action `build-spring-boot-image`:
  - Added the possibility to override the maven invocations with inputs `dsb-build-envs.spring-boot-build-image-version-command` and `dsb-build-envs.spring-boot-build-image-command`.
  - Added the possibility to override the maven arguments with the inputs `dsb-build-envs.spring-boot-build-image-version-arguments` and `dsb-build-envs.spring-boot-build-image-arguments`.
  - Added the possibility to override the maven goals with the inputs `dsb-build-envs.spring-boot-build-image-version-goals` and `dsb-build-envs.spring-boot-build-image-goals`.
  - Removed support for inputs `mvn-goals` and `mvn-args`.