### PR TITLE
Improvement: Deploy to static from more branches

### DIFF
--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -78,7 +78,8 @@ jobs:
 
       - name: 🎰 Generate DSB build variables
         id: build-env
-        uses: dsb-norge/github-actions/ci-cd/create-build-envs@v1
+        # TODO change '@v1.6' to '@v1' before merge to main
+        uses: dsb-norge/github-actions/ci-cd/create-build-envs@v1.6
         with:
           app-vars: ${{ toJSON(matrix.app-vars) }}
           maven-repo-username: ${{ secrets.maven-repo-username }}
@@ -136,11 +137,10 @@ jobs:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
       - name: 🐙 Deploy to static environment(s)
-        # Skip step when closing a PR, and only run for vue apps
-        if: |
-          github.ref == 'refs/heads/main' &&
-          ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' )
-        uses: dsb-norge/github-actions/ci-cd/deploy-to-static@v1
+        # Skip step for PRs, action will check if triggered from main branch
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        # TODO change '@v1.6' to '@v1' before merge to main
+        uses: dsb-norge/github-actions/ci-cd/deploy-to-static@v1.6
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 

--- a/ci-cd/create-build-envs/action.yml
+++ b/ci-cd/create-build-envs/action.yml
@@ -95,10 +95,16 @@ inputs:
     default: ''
   static-deploy-environments:
     description: |
-      Comma separated list of static environments to deploy to when building from main.
+      Comma separated list of static environments to deploy to.
       Application configuration for these must be defined in 'app-config-repo'.
     required: false
     default: dev, test
+  static-deploy-from-default-branch-only:
+    description: |
+      Set this to 'false' to allow deploying to static environments from other branches than the default branch.
+      The default is to allow only deploys from the default branch.
+    required: false
+    default: 'true'
   pr-deploy-app-config-branch:
     description: |
       Name of branch in "app-config-repo" potentially containing modified app config used during deploy to ephemeral

--- a/ci-cd/delete-pr-images-from-acr/action.yml
+++ b/ci-cd/delete-pr-images-from-acr/action.yml
@@ -24,9 +24,11 @@ runs:
           docker-image-repo
           application-image-name
 
+    # require pull request for this action to run
     - shell: bash
       run: |
         # Check if triggered by pull request event
+
         [ ! '${{ github.event_name }}' == 'pull_request' ] \
           && echo 'ERROR: delete-pr-images-from-acr: This action should only be called by pull request events.' \
           && EXIT_CODE=1 \
@@ -42,6 +44,7 @@ runs:
     - shell: bash
       run: |
         # Delete PR image repository from ACR
+
         az acr repository delete \
           --name ${{ fromJSON(inputs.dsb-build-envs).docker-image-registry }} \
           --repository ${{ fromJSON(inputs.dsb-build-envs).docker-image-repo }}/${{ fromJSON(inputs.dsb-build-envs).application-image-name }} \

--- a/ci-cd/deploy-to-static/action.yml
+++ b/ci-cd/deploy-to-static/action.yml
@@ -7,7 +7,12 @@ description: |
 author: 'Peder Schmedling'
 inputs:
   dsb-build-envs:
-    description: 'DSB build environment variables JSON.'
+    description: |
+      DSB build environment variables JSON.
+      Required fields:
+        See first step.
+      Optional fields:
+        None.
     required: true
 runs:
   using: 'composite'
@@ -22,6 +27,25 @@ runs:
           app-config-repo
           app-config-repo-token
           static-deploy-environments
+          static-deploy-from-default-branch-only
+
+    # check what branch we are deploying from
+    - shell: bash
+      run: |
+        # Verify deploy is allowed from calling branch
+
+        echo "deploy-to-static: Action called from branch '${{ github.ref_name }}'"
+        REPO_DEFAULT_BRANCH=$(curl -s https://api.github.com/repos/${{ github.repository }} -H "Authorization: bearer ${{ github.token }}" | jq -r .default_branch)
+        echo "deploy-to-static: Default branch of repo is '${REPO_DEFAULT_BRANCH}'"
+
+        if [ "${{ github.ref_name }}" == "${REPO_DEFAULT_BRANCH}" ]; then
+          echo "deploy-to-static: OK: deploy from default branch is allowed."
+        elif [ "${{ fromJSON(inputs.dsb-build-envs).static-deploy-from-default-branch-only }}" == 'false' ]; then
+          echo "deploy-to-static: OK: deploy from non-default branch is allowed as 'dsb-build-envs.static-deploy-from-default-branch-only' is set to 'false'."
+        else
+          echo "ERROR: deploy-to-static: deploy from non-default branch is NOT allowed because 'dsb-build-envs.static-deploy-from-default-branch-only' is set to '${{ fromJSON(inputs.dsb-build-envs).static-deploy-from-default-branch-only }}'."
+          exit 1
+        fi
 
     # checkout config repo
     - uses: actions/checkout@v2

--- a/ci-cd/prune-images-from-acr/action.yml
+++ b/ci-cd/prune-images-from-acr/action.yml
@@ -4,7 +4,12 @@ description: |
 author: 'Peder Schmedling'
 inputs:
   dsb-build-envs:
-    description: 'DSB build environment variables JSON.'
+    description: |
+      DSB build environment variables JSON.
+      Required fields:
+        See first step.
+      Optional fields:
+        None.
     required: true
 runs:
   using: 'composite'

--- a/ci-cd/require-build-envs/action.yml
+++ b/ci-cd/require-build-envs/action.yml
@@ -6,7 +6,12 @@ description: |
 author: 'Peder Schmedling'
 inputs:
   dsb-build-envs:
-    description: 'DSB build environment variables JSON.'
+    description: |
+      DSB build environment variables JSON.
+      Required fields:
+        Depends on 'input.require'.
+      Optional fields:
+        None.
     required: true
   require:
     description: 'Newline delimited string of variable names to test.'

--- a/ci-cd/teardown-pr-environment/action.yml
+++ b/ci-cd/teardown-pr-environment/action.yml
@@ -4,20 +4,16 @@ description: |
 author: 'Peder Schmedling'
 inputs:
   dsb-build-envs:
-    description: 'DSB build environment variables JSON.'
+    description: |
+      DSB build environment variables JSON.
+      Required fields:
+        See first step.
+      Optional fields:
+        None.
     required: true
 runs:
   using: 'composite'
   steps:
-    - shell: bash
-      run: |
-        # Check if triggered by pull request event
-        [ ! '${{ github.event_name }}' == 'pull_request' ] \
-          && echo 'ERROR: teardown-pr-environment: This action should only be called by pull request events.' \
-          && EXIT_CODE=1 \
-          || EXIT_CODE=0
-        exit ${EXIT_CODE}
-
     # we need to verify inputs since they are optional input to create-build-envs action
     - uses: dsb-norge/github-actions/ci-cd/require-build-envs@v1
       with:
@@ -29,6 +25,17 @@ runs:
           pr-deploy-k8s-namespace
           pr-deploy-k8s-application-name
 
+    # require pull request for this action to run
+    - shell: bash
+      run: |
+        # Check if triggered by pull request event
+
+        [ ! '${{ github.event_name }}' == 'pull_request' ] \
+          && echo 'ERROR: teardown-pr-environment: This action should only be called by pull request events.' \
+          && EXIT_CODE=1 \
+          || EXIT_CODE=0
+        exit ${EXIT_CODE}
+
     # set target k8s cluster
     - uses: Azure/aks-set-context@v1
       with:
@@ -36,13 +43,15 @@ runs:
         cluster-name: ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-aks-cluster-name }}
         resource-group: ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-aks-resource-group }}
 
-    # remove helm deployment
     - shell: bash
       run: |
-        helm uninstall ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-k8s-application-name }} \
-        --namespace ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-k8s-namespace }}
+        # Remove helm deployment
 
-    # remove namespace
+        helm uninstall ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-k8s-application-name }} \
+          --namespace ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-k8s-namespace }}
+
     - shell: bash
       run: |
+        # Remove namespace
+
         kubectl delete namespace ${{ fromJSON(inputs.dsb-build-envs).pr-deploy-k8s-namespace }}


### PR DESCRIPTION
# Improvements
- Action deploy-to-static:
  - Now checks the calling branch. The default behvior is to fail the run if called from non-default branch of the repo.
  - The branch check can be disabled by setting `static-deploy-from-default-branch-only` to `false`.
- Workflow ci-cd-default: Remove check on hardcoded branch `main` before calling the `deploy-to-static` action as this is now handled by the action itself.