### PR TITLE
Improvement: AdoptOpenJDK -> Eclipse Temurin

### DIFF
--- a/ci-cd/create-build-envs/action.yml
+++ b/ci-cd/create-build-envs/action.yml
@@ -75,7 +75,7 @@ inputs:
   java-distribution:
     description: 'Distribution of Java specified when calling actions/setup-java'
     required: false
-    default: adopt
+    default: temurin
   nodejs-version:
     description: 'Version of Node.js specified when calling actions/setup-node'
     required: false


### PR DESCRIPTION
# Improvements
- Action create-build-envs:
  - Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).