### PR TITLE
Deploy-artifacts

### DIFF
--- a/ci-cd/README.md
+++ b/ci-cd/README.md
@@ -23,3 +23,73 @@ ci-cd/
 These actions are used by the CI/CD workflow(s) in [./workflows](../workflows). For example usage see their usage in those workflows.
 
 For documentation refer to the `description` section of each specific actions as well as comments within their defintion.
+
+## Maintenance
+
+### Development
+
+1. Replace version-tag of all dsb-actions in this repo with a temporary tag, ex. `@v1` becomes `@my-feature`.
+
+    Replace regex pattern for vscode:
+    - Find: `(^\s*)((- ){0,1}uses: dsb-norge/github-actions/.*@)v1`
+    - Replace: `$1# TODO revert to @v1\n$1$2my-feature`
+
+1. Make your changes and commit your changes on a branch, for example `my-feature-branch`.
+2. Tag latest commit on you branch:
+   ```bash
+   git tag -f -a 'my-feature'
+   git push -f --tags
+   ```
+3. To try out your changes, in the calling repo change the calling workflow to call using your **branch name**. Ex. with a dev branch named `my-feature-branch`:
+   ```yaml
+    jobs:
+        ci-cd:
+            # TODO revert to '@v1'
+            uses: dsb-norge/github-actions/.github/workflows/ci-cd-default.yml@my-feature-branch
+   ```
+4. Test your changes from the calling repo. Make changes and remember to always move your tag `my-feature` to the latest commit.
+5. When ready remove your temporary tag:
+   ```bash
+   git tag --delete 'my-feature'
+   git push --delete origin 'my-feature'
+   ```
+    and revert from using the temporary tag to the version-tag for your release in actions, ie. `@my-feature` becomes `@v1` or `@v2` or wahtever.
+
+    Replace regex pattern for vscode:
+    - Find: `(^\s*# TODO revert to @v1\n)(^\s*)((- )?uses: dsb-norge/github-actions/.*@)my-feature`
+    - Replace: `$2$3v1`
+6. Create PR and merge to main.
+
+### Release
+
+After merge to main use tags to release.
+
+#### Minor release
+
+Ex. for smaller backwards compatible changes. Add a new minor version tag ex `v1.8` with a description of the changes and ammend the description to the major version tag.
+
+Example with release `v1.8`:
+```bash
+git checkout origin/main
+git pull origin main
+git tag -a 'v1.8'
+# you are promted for the tag annotation (change description)
+git tag -f -a 'v1'
+# you are promted for the tag annotation, ammend the change description
+git push -f --tags
+```
+
+#### Major release
+
+Same as minor release only the major version tag is a new one. Ie. we do not need to force tag/push.
+
+Example with release `v2`:
+```bash
+git checkout origin/main
+git pull origin main
+git tag -a 'v2.0'
+# you are promted for the tag annotation (change description)
+git tag -a 'v2'
+# you are promted for the tag annotation
+git push --tags
+```

--- a/ci-cd/build-maven-project/action.yml
+++ b/ci-cd/build-maven-project/action.yml
@@ -34,6 +34,17 @@ description: |
           Otherwise default argument will be used: '-B'.
         - The pom file used will be the one defined by 'application-source-path' in 'dsb-build-envs', can point either to an existing pom.xml or to a directory containing it.
         - The resulting maven invocation command is: mvn <arguments> --file <pom file> <goals>
+  Deploy of build artifacts:
+    - Configure repos in the pom.xml and set one ore both of the following to 'true':
+      - 'maven-build-project-deploy-release-artifacts'
+        - Will deploy artifacts with 'mvn deploy -DskipTests'
+        - To the maven repo configured under <distributionManagement><repository>
+        - Will only deploy artifacts when building from default branch of repo (normally main).
+      - 'maven-build-project-deploy-snapshot-artifacts'
+        - Will invoke 'mvn versions:set -DnewVersion=<version>-SNAPSHOT'
+        - Will deploy artifacts with 'mvn deploy -DskipTests'
+        - To the maven repo configured under <distributionManagement><snapshotRepository>
+        - Will only deploy artifacts when building from PR.
 author: 'Peder Schmedling'
 inputs:
   mvn-version-cmd:
@@ -60,6 +71,8 @@ inputs:
         maven-build-project-command
         maven-build-project-goals
         maven-build-project-arguments
+        maven-build-project-deploy-release-artifacts
+        maven-build-project-deploy-snapshot-artifacts
     required: true
 
 runs:
@@ -80,6 +93,8 @@ runs:
           sonarqube-token
           maven-repo-token
           maven-repo-username
+          caller-repo-calling-branch
+          caller-repo-is-on-default-branch
 
     # locate pom.xml and define maven commands
     - id: mvn-cmd
@@ -209,5 +224,90 @@ runs:
         JASYPT_LOCAL_ENCRYPTOR_PASSWORD: ${{ fromJSON(inputs.dsb-build-envs).jasypt-password }}
         GITHUB_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).github-repo-token }} # Needed for Sonar to get PR information, if any
         SONAR_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).sonarqube-token }}
+        DSB_MAVEN_REPO_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-token }}
+        DSB_MAVEN_REPO_USER_NAME: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-username }}
+
+    # deploy maven build artifacts
+    - shell: bash
+      run: |
+        # Use maven to deploy artifacts when allowed and requested
+
+        BUILD_ENVS=$(cat <<'EOF'
+        ${{ inputs.dsb-build-envs }}
+        EOF
+        )
+
+        # Helper functions
+        # Get field value from BUILD_ENVS safely
+        function get-val { echo "${BUILD_ENVS}" | jq -r --arg name "$1" '.[$name]'; }
+
+        # Locate pom.xml
+        POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}"
+        [ ! -f "${POM_FILE}" ] && POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}/pom.xml"
+        [ ! -f "${POM_FILE}" ] && \
+          echo "ERROR: build-dsb-maven-project: Deploy artifacts: Cannot find pom.xml. Both '${{ fromJSON(inputs.dsb-build-envs).application-source-path }}' and '${POM_FILE}' does not exist!" && \
+          exit 1
+
+        # Determine if we are deploying and with what commands
+        if [ '${{ github.event_name }}' == 'pull_request' ]; then
+          if [ '${{ github.event.action }}' == 'closed' ]; then
+            echo "build-dsb-maven-project: Deploy artifacts: Maven snapshot artifacts will not be deployed when closing PR."
+            exit 0
+          elif [ ! "$(get-val 'maven-build-project-deploy-snapshot-artifacts')" == 'true' ]; then
+            echo "build-dsb-maven-project: Deploy artifacts: Deployment of maven snapshot artifacts not requested."
+            exit 0
+          else
+            echo "build-dsb-maven-project: Deploy artifacts: Will deploy maven snapshot artifacts as requested."
+            MVN_VERSION_CMD="mvn -B --file ${POM_FILE} versions:set -DnewVersion=pr-${{ github.event.number }}-SNAPSHOT"
+            MVN_CMD="mvn -B --file ${POM_FILE} deploy -DskipTests"
+          fi
+        elif [ '${{ github.event_name }}' == 'push' ] || [ '${{ github.event_name }}' == 'workflow_dispatch' ]; then
+          if [ ! '${{ fromJSON(inputs.dsb-build-envs).caller-repo-is-on-default-branch }}' == 'true' ]; then
+            echo "build-dsb-maven-project: Deploy artifacts: Maven release artifacts will not be deployed as current branch '${{ fromJSON(inputs.dsb-build-envs).caller-repo-calling-branch }}' is not the default of this repo."
+            exit 0
+          elif [ ! "$(get-val 'maven-build-project-deploy-release-artifacts')" == 'true' ]; then
+            echo "build-dsb-maven-project: Deploy artifacts: Deployment of maven release artifacts not requested."
+            exit 0
+          else
+            echo "build-dsb-maven-project: Deploy artifacts: Will deploy maven release artifacts as requested."
+            # Version is already set corretly in build step
+            MVN_VERSION_CMD=
+            MVN_CMD="mvn -B --file ${POM_FILE} deploy -DskipTests"
+          fi
+        else
+          echo "ERROR: build-dsb-maven-project: Deploy artifacts: unsupported github.event_name '${{ github.event_name }}' with github.event.action '${{ github.event.action }}'!"
+          exit 1
+        fi
+
+        # Load extra envs if any
+        EXTRA_ENVS=$(cat <<'EOF'
+        ${{ inputs.set-extra-envs }}
+        EOF
+        )
+        if [ ! -z "$EXTRA_ENVS" ]; then
+          echo "::group::build-dsb-maven-project: Deploy artifacts: extra environment variables"
+          JSON_FIELDS=$(echo ${EXTRA_ENVS} | jq -r '[keys[]] | join(" ")')
+          for JSON_FIELD in ${JSON_FIELDS}; do
+              JSON_VALUE=$(echo ${EXTRA_ENVS} | jq -r ".${JSON_FIELD}")
+              echo "Setting extra environment variable '${JSON_FIELD}'"
+              export "${JSON_FIELD}"="${JSON_VALUE}"
+          done
+          echo "::endgroup::"
+        fi
+
+        if [ -z "${MVN_VERSION_CMD}" ]; then
+          echo "build-dsb-maven-project: Deploy artifacts: Project version already set by maven."
+        else
+          echo "::group::build-dsb-maven-project: Setting maven project version for deployment of artifacts"
+          echo "build-dsb-maven-project: Deploy artifacts: command string: '${MVN_VERSION_CMD}'"
+          ${MVN_VERSION_CMD}
+          echo "::endgroup::"
+        fi
+
+        echo "::group::build-dsb-maven-project: Deploy artifacts: Invoke maven"
+        echo "build-dsb-maven-project: Deploy artifacts: command string: '${MVN_CMD}'"
+        ${MVN_CMD}
+        echo "::endgroup::"
+      env:
         DSB_MAVEN_REPO_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-token }}
         DSB_MAVEN_REPO_USER_NAME: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-username }}

--- a/ci-cd/build-spring-boot-image/action.yml
+++ b/ci-cd/build-spring-boot-image/action.yml
@@ -237,13 +237,36 @@ runs:
         echo "::set-output name=mvn-cmd::${MVN_CMD}"
         echo "::set-output name=local-image-id::${LOCAL_IMAGE_ID}"
 
+    # filter dsb-build-envs
+    - id: filter-build-envs
+      shell: bash
+      run: |
+        # Make sure build-maven-project action does not attempt to deploy maven artifacts
+
+        BUILD_ENVS=$(cat <<'EOF'
+        ${{ inputs.dsb-build-envs }}
+        EOF
+        )
+
+        # Helper functions
+        # Add/overwrite fields in BUILD_ENVS safely
+        function set-field { BUILD_ENVS=$(echo "${BUILD_ENVS}" | jq --arg name "$1" --arg value "$2" '.[$name] = $value') ; }
+
+        set-field 'maven-build-project-deploy-release-artifacts'  'false'
+        set-field 'maven-build-project-deploy-snapshot-artifacts' 'false'
+
+        # Escape (%, linefeed and carriage return) and return data
+        function escape-for-output { local ESCAPED="${1//'%'/'%25'}"; ESCAPED="${ESCAPED//$'\n'/'%0A'}"; ESCAPED="${ESCAPED//$'\r'/'%0D'}"; echo "${ESCAPED}" ; }
+        BUILD_ENVS_ESC=$(escape-for-output "${BUILD_ENVS}")
+        echo "::set-output name=dsb-build-envs::${BUILD_ENVS_ESC}"
+
     # build docker image
     - uses: dsb-norge/github-actions/ci-cd/build-maven-project@v1
       with:
         mvn-version-cmd: ${{ steps.mvn-cmd.outputs.mvn-version-cmd }}
         mvn-cmd: ${{ steps.mvn-cmd.outputs.mvn-cmd }}
         set-extra-envs: ${{ steps.extra-envs.outputs.json }}
-        dsb-build-envs: ${{ inputs.dsb-build-envs }}
+        dsb-build-envs: ${{ steps.filter-build-envs.outputs.dsb-build-envs }}
 
     # tag and push docker image
     - shell: bash

--- a/ci-cd/create-app-vars-matrix/action.yml
+++ b/ci-cd/create-app-vars-matrix/action.yml
@@ -364,12 +364,18 @@ runs:
         EOF
         )
 
-        # Github matrix is on format '{"include":[]}', reshape IN_JSON to conform to this:
-        # Each element in the array will have one field 'app-vars' containing all app vars
-        OUT_JSON=$(echo "${IN_JSON}" | jq 'map({ "app-vars": . }) | { "include": . }')
+        # Reshape JSON to conform to github matrix format:
+        #{
+        #  "application-name":["name"],
+        #  "include":[
+        #    {"application-name":"name","app-vars":{}}
+        #  ]
+        #}
+        # Each element in the array will have one field 'app-vars' containing all app vars for a given app
+        OUT_JSON=$(echo "${IN_JSON}" | jq '{ "application-name": map( .["application-name"]), "include": map({ "application-name": .["application-name"], "app-vars": . }) }')
 
         # Log the result
-        echo "::group::create-app-vars-matrix-matrix: app vars JSON re-formated for Github matrix job"
+        echo "::group::create-app-vars-matrix: app vars JSON re-formated for Github matrix job"
         echo "${OUT_JSON}"
         echo "::endgroup::"
 

--- a/ci-cd/create-build-envs/action.yml
+++ b/ci-cd/create-build-envs/action.yml
@@ -221,6 +221,9 @@ runs:
           application-source-revision
           docker-image-prune-keep-min-images
           docker-image-prune-keep-num-days
+          caller-repo-default-branch
+          caller-repo-calling-branch
+          caller-repo-is-on-default-branch
         )
 
         # Helper functions
@@ -295,12 +298,22 @@ runs:
           done
         fi
 
+        # Calling repo branches information
+        REPO_DEFAULT_BRANCH=$(curl -s https://api.github.com/repos/${{ github.repository }} -H "Authorization: bearer ${{ github.token }}" | jq -r .default_branch)
+        REPO_CURERNT_BRANCH_IS_DEFAULT=false
+        if [ "${{ github.ref_name }}" == "${REPO_DEFAULT_BRANCH}" ]; then
+          REPO_CURERNT_BRANCH_IS_DEFAULT=true
+        fi
+
         # Generated fields, not possible to override from app vars
         IMAGE_ID="$(get-val 'docker-image-registry')/$(get-val 'docker-image-repo')/$(get-val 'application-image-name')"
-        set-field "application-image-id"        "${IMAGE_ID}"
-        set-field "pr-deploy-app-config-branch" '${{ steps.checkout-config-branch.outputs.ref }}'
-        set-field "application-source"          '${{ github.server_url }}/${{ github.repository }}'
-        set-field "application-source-revision" '${{ github.sha }}'
+        set-field "application-image-id"              "${IMAGE_ID}"
+        set-field "pr-deploy-app-config-branch"       '${{ steps.checkout-config-branch.outputs.ref }}'
+        set-field "application-source"                '${{ github.server_url }}/${{ github.repository }}'
+        set-field "application-source-revision"       '${{ github.sha }}'
+        set-field "caller-repo-default-branch"        "${REPO_DEFAULT_BRANCH}"
+        set-field "caller-repo-calling-branch"        "${{ github.ref_name }}"
+        set-field "caller-repo-is-on-default-branch"  "${REPO_CURERNT_BRANCH_IS_DEFAULT}"
 
         echo "create-build-envs: Number of envs: $(echo ${OUTPUT_ENV_JSON} | jq 'length')"
 

--- a/ci-cd/deploy-to-static/action.yml
+++ b/ci-cd/deploy-to-static/action.yml
@@ -28,17 +28,19 @@ runs:
           app-config-repo-token
           static-deploy-environments
           static-deploy-from-default-branch-only
+          caller-repo-default-branch
+          caller-repo-calling-branch
+          caller-repo-is-on-default-branch
 
     # check what branch we are deploying from
     - shell: bash
       run: |
         # Verify deploy is allowed from calling branch
 
-        echo "deploy-to-static: Action called from branch '${{ github.ref_name }}'"
-        REPO_DEFAULT_BRANCH=$(curl -s https://api.github.com/repos/${{ github.repository }} -H "Authorization: bearer ${{ github.token }}" | jq -r .default_branch)
-        echo "deploy-to-static: Default branch of repo is '${REPO_DEFAULT_BRANCH}'"
+        echo "deploy-to-static: Action called from branch '${{ fromJSON(inputs.dsb-build-envs).caller-repo-calling-branch }}'"
+        echo "deploy-to-static: Default branch of repo is '${{ fromJSON(inputs.dsb-build-envs).caller-repo-default-branch }}'"
 
-        if [ "${{ github.ref_name }}" == "${REPO_DEFAULT_BRANCH}" ]; then
+        if [ '${{ fromJSON(inputs.dsb-build-envs).caller-repo-is-on-default-branch }}' == 'true' ]; then
           echo "deploy-to-static: OK: deploy from default branch is allowed."
         elif [ "${{ fromJSON(inputs.dsb-build-envs).static-deploy-from-default-branch-only }}" == 'false' ]; then
           echo "deploy-to-static: OK: deploy from non-default branch is allowed as 'dsb-build-envs.static-deploy-from-default-branch-only' is set to 'false'."


### PR DESCRIPTION
# Improvements
- Action `create-build-envs`: 
  - Add information about caller repo branch. `caller-repo-default-branch`, `caller-repo-calling-branch` and `caller-repo-is-on-default-branch`.
- Action `deploy-to-static`: 
  - Use information about caller repo branch from the `create-build-envs` action.
- Action `maven-build-project`: 
  - Support maven build artifact deploy: 
    - Will deploy maven snapshot artifacts when running on PR and `maven-build-project-deploy-snapshot-artifacts` is true.   
    - Will deploy maven release artifacts when running from default branch (push or manually triggered) and `maven-build-project-deploy-release-artifacts` is true.   
    - Requires `distributionManagement` configuration in project pom.xml. - Action build-spring-boot-image: Make sure build-maven-project action does not attempt to deploy maven artifacts when invoked from this action.
- CI/CD: README: Add dev notes
- Action `create-app-vars-matrix`: 
  - Better naming of matrix jobs in github UI: By re-shaping the matrix job input the github UI will show the matrix jobs named by the application being built. Having matrix jobs with static names makes it possible to use them as checks in branch protection rules.