### PR TITLE
TU-2166: Replacing default github token with repo scoped personal acc…

### DIFF
--- a/.github/workflows/update-deps-and-create-pr.yml
+++ b/.github/workflows/update-deps-and-create-pr.yml
@@ -84,6 +84,7 @@ jobs:
         # See https://github.com/peter-evans/create-pull-request for details.
         uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # 3.14.0
         with:
+          token: ${{ secrets.GITOPS_TAG_BUMPER_TOKEN }}
           commit-message: Updating third party dependencies
           committer: Auto maven versions update <noreply@dsb.no>
           author: Auto maven versions update <noreply@dsb.no>

--- a/.github/workflows/update-deps-and-create-pr.yml
+++ b/.github/workflows/update-deps-and-create-pr.yml
@@ -84,6 +84,8 @@ jobs:
         # See https://github.com/peter-evans/create-pull-request for details.
         uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # 3.14.0
         with:
+          # Pull requests created by the action using the default GITHUB_TOKEN cannot trigger other workflows.
+          # So, to trigger CI/CD (which verifies that the app can be built and deployed), we use a repo scoped personal access token (PAT).
           token: ${{ secrets.GITOPS_TAG_BUMPER_TOKEN }}
           commit-message: Updating third party dependencies
           committer: Auto maven versions update <noreply@dsb.no>


### PR DESCRIPTION
…ess token (PAT) so that github is allowed to trigger PR-triggered actions such as ci/cd.