### PR TITLE
Various improvements

### DIFF
--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -175,7 +175,8 @@ jobs:
 
       - name: 🗑 Delete PR docker images from ACR
         # Step only runs when closing a PR
-        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        # Step runs even if previous steps have failed, with the exception of 'build-env' which is required
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && always() && steps.build-env.outcome == 'success'
         uses: dsb-norge/github-actions/ci-cd/delete-pr-images-from-acr@v1
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}

--- a/ci-cd/README.md
+++ b/ci-cd/README.md
@@ -1,7 +1,7 @@
 # DSBs github CI/CD actions
 Collection of DSB custom github actions for CI/CD.
 
-## Index
+## File index
 ```
 ci-cd/
 ├───build-docker-image        --> Build, tag and push docker image
@@ -79,6 +79,8 @@ git tag -f -a 'v1'
 git push -f --tags
 ```
 
+**Note:** If you are having problems pulling main after a release, try to force fetch the tags: `git fetch --tags -f`.
+
 #### Major release
 
 Same as minor release except that the major version tag is a new one. I.e. we do not need to force tag/push.
@@ -93,3 +95,5 @@ git tag -a 'v2'
 # you are prompted for the tag annotation
 git push --tags
 ```
+
+**Note:** If you are having problems pulling main after a release, try to force fetch the tags: `git fetch --tags -f`.

--- a/ci-cd/deploy-to-ephemeral/action.yml
+++ b/ci-cd/deploy-to-ephemeral/action.yml
@@ -167,32 +167,7 @@ runs:
         echo "::set-output name=comment::${COMMENT_TEXT_ESC}"
 
     # add comment to PR
-    - uses: actions/github-script@v5
-      env:
-        DELETE_COMMENTS_WITH_PREFIX: ${{ steps.create-comment.outputs.prefix }}
-        NEW_COMMENT_BODY: ${{ steps.create-comment.outputs.comment }}
+    - uses: dsb-norge/github-actions/ci-cd/comment-on-pr@v1
       with:
-        script: |
-          const { DELETE_COMMENTS_WITH_PREFIX, NEW_COMMENT_BODY } = process.env
-          const opts = github.rest.issues.listComments.endpoint.merge({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo
-          })
-          const comments = await github.paginate(opts)
-          for (const comment of comments) {
-              if (comment.body.startsWith(`${DELETE_COMMENTS_WITH_PREFIX}`)) {
-                  console.log('deploy-to-ephemeral: Deleting comment -> id: ' + comment.id + ', body: ' + comment.body.slice(0,100))
-                  github.rest.issues.deleteComment({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      comment_id: comment.id
-                  });
-              }
-          }
-          return github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `${NEW_COMMENT_BODY}`
-          });
+        pr-comment-text: ${{ steps.create-comment.outputs.comment }}
+        delete-comments-starting-with: ${{ steps.create-comment.outputs.prefix }}


### PR DESCRIPTION
# Improvements
- ci/cd: `deploy-to-ephemeral`:
  - Use action `comment-on-pr` to comment on PRs instead of `github-script` directly.
- ci/cd: delete PR docker images:
  -  The step `Delete PR docker images from ACR` should run regardless of the outcome of the step `Teardown of ephemeral PR environment`.