### PR TITLE
feat: maven versions bumper v2

### DIFF
--- a/.github/workflows/maven-versions-bumper.yml
+++ b/.github/workflows/maven-versions-bumper.yml
@@ -1,0 +1,121 @@
+name: 'Update third party dependencies and create pull request'
+
+# In order to use this workflow a github app must be installed in the calling workflow's organization.
+# The app must at minimum have 'contents: write' and 'pull-requests: write' permissions in the repo of the calling workflow.
+#
+# The following variables must available in the github 'vars' context:
+#   - vars.ORG_MAVEN_BUMPER_APP_ID              <-- app id from here: https://github.com/organizations/dsb-norge/settings/apps/dsb-norge-maven-versions-bumper
+#   - vars.ORG_MAVEN_BUMPER_APP_INSTALLATION_ID <-- app installation id found in url if you "configure" the app 'dsb-norge-maven-versions-bumper' from here: https://github.com/organizations/dsb-norge/settings/installations
+#   - vars.ORG_MAVEN_REPO_USERNAME              <-- user with read and write to maven repo
+#
+# The following secrets must be available in the github 'secrets' context:
+#   - secrets.ORG_MAVEN_BUMPER_APP_PRIVATE_KEY  <-- generated from the app in github: https://github.com/organizations/dsb-norge/settings/apps/dsb-norge-maven-versions-bumper
+#   - secrets.ORG_MAVEN_REPO_TOKEN              <-- token for maven repo user
+
+on:
+  workflow_call:
+    inputs:
+      apps:
+        type: string
+        description: |
+          YAML list (as string) with specification of applications to update.
+          Required fields are:
+            - application-name        - string
+        required: true
+
+jobs:
+  create-matrix:
+    name: Create build matrix
+    runs-on: [self-hosted, dsb-builder, linux, x64]
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      app-vars-matrix: ${{ steps.create-matrix.outputs.app-vars }}
+
+    steps:
+      # The create-app-vars-matrix action requires source code to be available
+      - name: 🧹 Clean workspace
+        uses: dsb-norge/github-actions/directory-recreate@v1
+      - name: ⬇ Checkout working branch
+        uses: actions/checkout@v3
+
+      - name: 🎰 Create app vars build matrix
+        id: create-matrix
+        uses: dsb-norge/github-actions/ci-cd/create-app-vars-matrix@v1
+        with:
+          apps: ${{ inputs.apps }}
+
+  update-dependencies:
+    name: Update third party dependencies & create pull request
+    needs: create-matrix
+    runs-on: [self-hosted, dsb-builder, linux, x64]
+    strategy:
+      matrix: ${{ fromJSON(needs.create-matrix.outputs.app-vars-matrix) }}
+      fail-fast: false # allow all parallel jobs to continue even if one fails
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: 🧹 Clean workspace
+        uses: dsb-norge/github-actions/directory-recreate@v1
+
+      - name: ⬇ Checkout working branch
+        uses: actions/checkout@v3
+
+      - name: 🎰 Generate DSB build variables
+        id: build-env
+        uses: dsb-norge/github-actions/ci-cd/create-build-envs@v1
+        with:
+          app-vars: ${{ toJSON(matrix.app-vars) }}
+          maven-repo-username: ${{ vars.ORG_MAVEN_REPO_USERNAME }}
+          maven-repo-token: ${{ secrets.ORG_MAVEN_REPO_TOKEN }}
+
+      - name: "⚒ Spring Boot app: Run Maven command"
+        id: maven-bump
+        # only run for spring-boot apps
+        if: matrix.app-vars.application-type == 'spring-boot'
+        uses: dsb-norge/github-actions/run-maven-command@v1
+        with:
+          dsb-build-envs: ${{ steps.build-env.outputs.json }}
+          goals: versions:update-properties versions:update-parent
+          arguments: -DgenerateBackupPoms=false
+
+      - name: 🧹 Remove build info (so it won't be committed)
+        # only if maven command was not skipped and completed successfully
+        if: steps.maven-bump.outcome == 'success'
+        run: |
+          rm -rf _create-build-envs
+
+      - name: 🔑 Obtain GitHub app installation access token
+        id: auth
+        # only if maven command was not skipped and completed successfully
+        if: steps.maven-bump.outcome == 'success'
+        uses: dsb-norge/github-actions/get-github-app-installation-token@v1
+        with:
+          github-app-id: ${{ vars.ORG_MAVEN_BUMPER_APP_ID }}
+          github-app-installation-id: ${{ vars.ORG_MAVEN_BUMPER_APP_INSTALLATION_ID }}
+          github-app-private-key: '${{ secrets.ORG_MAVEN_BUMPER_APP_PRIVATE_KEY }}'
+          token-request-body: '{"repository":"${{ github.repository }}","permissions":{"contents":"write","pull_requests":"write"}}'
+
+      - name: 🌱 Commit to new branch (or update existing) & create pull request
+        # only if maven command was not skipped and completed successfully
+        if: steps.maven-bump.outcome == 'success'
+        # Will update branch if it already exists.
+        # See https://github.com/peter-evans/create-pull-request for details.
+        uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7 # 4.2.0
+        with:
+          # Pull requests created by the action using the default GITHUB_TOKEN cannot trigger other workflows.
+          # So to trigger CI/CD (which verifies that the app can be built and deployed), we use the github app installation token.
+          token: ${{ steps.auth.outputs.github-token }}
+          commit-message: Updating third party dependencies
+          committer: Auto maven versions update <noreply@dsb.no>
+          author: Auto maven versions update <noreply@dsb.no>
+          branch: automatic-maven-versions-update_${{ matrix.app-vars.application-name }}
+          delete-branch: true
+          title: Automatic dependency update
+          body: Automatic update of third party dependencies
+          labels: |
+            automatic dependency update

--- a/README.md
+++ b/README.md
@@ -1,43 +1,13 @@
 # DSBs github actions
 Collection of DSB custom github actions and reusable workflows.
 
+
 ## Index
 ```
 /
-├───.github/workflows   --> Collection of reusable workflows, see separate README.md.
-├───ci-cd               --> Collection of CI/CD actions, see separate README.md.
-└───directory-recreate  --> Action for `rm -rf && mkdir`, see doc below.
-```
-
-## Usage and doc
-### Action: directory-recreate
-
-**USE WITH CAUTION!**
-
-This action removes and a directory including all files and sub-directories within, afterwards the directory is recreated. The directory will be re-created with `rwx` permissions for `user` and no permissions for `group,others`. The action will list out the directory contents before and after the delete operation.
-
-### **Inputs**
-#### **`directory`**
-
-**Optional** The directory to remove and re-create.
-
-**NOTE:** If no directory is specified, the `${{ github.workspace }}` directroy will be used.
-
-#### **`recreate`**
-
-**Optional** If the directory should be re-created or not.
-
-### **Example: Clean the workspace directory**
-Removes and re-creates the github workspace directory.
-```yaml
-- uses: dsb-norge/github-actions/directory-recreate@v1
-```
-
-### **Example: Remove a specific directory**
-Removes `my-cache-dir` (in the current working directory) and does not re-create it.
-```yaml
-- uses: dsb-norge/github-actions/directory-recreate@v1
-  with:
-    directory: ./my-cache-dir
-    recreate: false
+├───.github/workflows                 --> Collection of reusable workflows, see separate README.md.
+├───ci-cd                             --> Collection of CI/CD actions, see separate README.md.
+├───directory-recreate                --> Action for `rm -rf && mkdir`, see description in action.yml
+├───get-github-app-installation-token --> Action to auth as an App, see description in action.yml
+└───run-maven-command                 --> Action to call maven, see description in action.yml
 ```

--- a/get-github-app-installation-token/action.yml
+++ b/get-github-app-installation-token/action.yml
@@ -1,0 +1,67 @@
+name: '🔑 Obtain GitHub app installation access token'
+description: |
+  Given the required input this action returns a GitHub App installation access token that enables a GitHub App to make
+  authenticated API requests for the app's installation on an organization or individual account.
+inputs:
+  github-app-id:
+    description: |
+      Id of a GitHub App.
+      ref. https://github.com/marketplace?type=apps
+    required: true
+  github-app-installation-id:
+    description: 'Unique identifier of the installation of the GitHub App installed on an organization or individual account.'
+    required: true
+  github-app-private-key:
+    description: |
+      The private key to use when authenticating as a GitHub App. This key is used to sign the JWT.
+      ref. https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app
+    required: true
+  token-request-body:
+    description: |
+      Request body of the installation access token POST request. Can be used to scope down the aquired token.
+      ref. https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app
+    required: false
+    default: ''
+outputs:
+  github-token:
+    description: |
+      The obtained GitHub App installation access token. This can ex. be used to make REST API requests as the App.
+    value: ${{ steps.get-token.outputs.github-token }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: get-token
+      shell: bash
+      run: |
+        # Auth as GiHub App and retreive GitHub App installation access token.
+
+        # Helper functions
+        function log-info { echo "get-github-app-installation-token: $*"; }
+
+        log-info "Minting JWT ..."
+        JWT_HEADER=$(jq -c -r . <<<"{\"alg\": \"RS256\", \"typ\": \"JWT\"}")
+        JWT_HEADER_64=$(echo -n "${JWT_HEADER}" | openssl enc -base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
+        JWT_PAYLOAD=$(jq -c -r . <<<"{\"exp\": $(date +%s -d +10minutes), \"iat\": $(date +%s -d -60seconds), \"iss\": \"${{ inputs.github-app-id }}\"}")
+        JWT_PAYLOAD_64=$(echo -n "${JWT_PAYLOAD}" | openssl enc -base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
+        JWT_SIGN_64=$(printf '%s.%s' "${JWT_HEADER_64}" "${JWT_PAYLOAD_64}" | openssl dgst -sha256 -binary -sign <(printf '%s\n' "${GH_APP_KEY}") | openssl enc -base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
+        JWT=$(echo -n "${JWT_HEADER_64}.${JWT_PAYLOAD_64}.${JWT_SIGN_64}")
+        unset JWT_HEADER JWT_HEADER_64 JWT_PAYLOAD JWT_PAYLOAD_64 JWT_SIGN_64 GH_APP_KEY
+
+        log-info "Exchanging JWT for a installation access token ..."
+        GH_APP_TOKEN_RESPONSE=$(
+          curl -s --request POST \
+            --url "https://api.github.com/app/installations/${{ inputs.github-app-installation-id }}/access_tokens" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${JWT}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            -d '${{ inputs.token-request-body }}'
+        )
+
+        # echo "DEBUG: get-github-app-installation-token: exit code: $?"
+        # echo "DEBUG: get-github-app-installation-token: response | jq: $(echo "${GH_APP_TOKEN_RESPONSE}" | jq)"
+
+        log-info "Returning the installation access token ..."
+        echo "github-token=$(echo "${GH_APP_TOKEN_RESPONSE}" | jq -r '.token')" >> $GITHUB_OUTPUT
+      env:
+        GH_APP_KEY: "${{ inputs.github-app-private-key }}"


### PR DESCRIPTION
# new features
- New action `get-github-app-installation-token` for authentication as GitHub App installation.
- New reusable workflow `maven-versions-bumper` to supersede `update-deps-and-create-pr`. This workflow authenticates as a GitHub App installation (instead of using PAT).