### PR TITLE
Support for deployment to Github Packages

### DIFF
--- a/ci-cd/build-maven-project/action.yml
+++ b/ci-cd/build-maven-project/action.yml
@@ -107,6 +107,7 @@ inputs:
         maven-build-project-deploy-snapshot-artifacts
         maven-build-project-deploy-snapshot-version-command
         maven-build-project-deploy-snapshot-deploy-command
+        maven-build-project-github-packages-enabled
     required: true
 
 runs:
@@ -273,7 +274,7 @@ runs:
         DSB_MAVEN_REPO_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-token }}
         DSB_MAVEN_REPO_USER_NAME: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-username }}
 
-    # deploy maven build artifacts
+    # deploy maven build artifacts to Nexus
     - shell: bash
       run: |
         # Use maven to deploy artifacts when allowed and requested
@@ -288,8 +289,8 @@ runs:
         function has-field { if [[ "$(echo "${BUILD_ENVS}"| jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
         # Get field value from BUILD_ENVS safely
         function get-val { echo "${BUILD_ENVS}" | jq -r --arg name "$1" '.[$name]'; }
-        function log-info { echo "build-dsb-maven-project: Deploy artifacts: $*"; }
-        function log-error { echo "ERROR: build-dsb-maven-project: Deploy artifacts: $*"; }
+        function log-info { echo "build-dsb-maven-project: Deploy artifacts to Nexus: $*"; }
+        function log-error { echo "ERROR: build-dsb-maven-project: Deploy artifacts to Nexus: $*"; }
 
         # Locate pom.xml
         POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}"
@@ -388,3 +389,137 @@ runs:
       env:
         DSB_MAVEN_REPO_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-token }}
         DSB_MAVEN_REPO_USER_NAME: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-username }}
+
+    # create a new settings.xml with credentials for Github Packages
+    - uses: actions/setup-java@v3
+      with:
+        distribution: ${{ fromJSON(inputs.dsb-build-envs).java-distribution }}
+        java-version: ${{ fromJSON(inputs.dsb-build-envs).java-version }}
+        server-id: github-dsb-norge # Value of the repository/id field of the pom.xml
+        server-username: DSB_GH_PACKAGES_USER_NAME
+        server-password: DSB_GH_PACKAGES_REPO_TOKEN
+        overwrite-settings: true
+
+    # deploy maven build artifacts to Github Packages
+    - shell: bash
+      run: |
+        # Use maven to deploy artifacts when allowed and requested
+
+        BUILD_ENVS=$(cat <<'EOF'
+        ${{ inputs.dsb-build-envs }}
+        EOF
+        )
+
+        # Helper functions
+        # Check if field exists in BUILD_ENVS safely
+        function has-field { if [[ "$(echo "${BUILD_ENVS}"| jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
+        # Get field value from BUILD_ENVS safely
+        function get-val { echo "${BUILD_ENVS}" | jq -r --arg name "$1" '.[$name]'; }
+        function log-info { echo "build-dsb-maven-project: Deploy artifacts to Github Packages: $*"; }
+        function log-error { echo "ERROR: build-dsb-maven-project: Deploy artifacts to Github Packages: $*"; }
+
+        if [ ! "$(get-val 'maven-build-project-github-packages-enabled')" == 'true' ]; then
+            log-info "Maven artifacts will not be deployed to Github Packages as 'maven-build-project-github-packages-enabled' is not set to 'true'."
+            exit 0
+        fi
+
+        # Locate pom.xml
+        POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}"
+        [ ! -f "${POM_FILE}" ] && POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}/pom.xml"
+        [ ! -f "${POM_FILE}" ] && \
+          log-error "Cannot find pom.xml. Both '${{ fromJSON(inputs.dsb-build-envs).application-source-path }}' and '${POM_FILE}' does not exist!" && \
+          exit 1
+
+        ALT_DEPLOYMENT_REPOSITORY="-DaltDeploymentRepository=github-dsb-norge::default::https://maven.pkg.github.com/${{ github.repository }}"
+        log-info "ALT_DEPLOYMENT_REPOSITORY is now set to '${ALT_DEPLOYMENT_REPOSITORY}'"
+
+        # Determine if we are deploying and with what commands
+        if [ '${{ github.event_name }}' == 'pull_request' ]; then
+          if [ '${{ github.event.action }}' == 'closed' ]; then
+            log-info "Maven snapshot artifacts will not be deployed when closing PR."
+            exit 0
+          elif [ ! "$(get-val 'maven-build-project-deploy-snapshot-artifacts')" == 'true' ]; then
+            log-info "Deployment of maven snapshot artifacts not requested."
+            exit 0
+          else
+            log-info "Will deploy maven snapshot artifacts as requested."
+            if has-field 'maven-build-project-deploy-snapshot-version-command'; then
+              log-info "using maven version command from 'inputs.dsb-build-envs.maven-build-project-deploy-snapshot-version-command'."
+              MVN_VERSION_CMD="$(get-val 'maven-build-project-deploy-snapshot-version-command') -DnewVersion=pr-${{ github.event.number }}-SNAPSHOT ${ALT_DEPLOYMENT_REPOSITORY}"
+            else
+              log-info "using default maven version command."
+              MVN_VERSION_CMD="mvn -B --file ${POM_FILE} versions:set -DnewVersion=pr-${{ github.event.number }}-SNAPSHOT ${ALT_DEPLOYMENT_REPOSITORY}"
+            fi
+            if has-field 'maven-build-project-deploy-snapshot-deploy-command'; then
+              log-info "using maven deploy command from 'inputs.dsb-build-envs.maven-build-project-deploy-snapshot-deploy-command'."
+              MVN_CMD="$(get-val 'maven-build-project-deploy-snapshot-deploy-command')"
+            else
+              log-info "using default maven deploy command."
+              MVN_CMD="mvn -B --file ${POM_FILE} deploy -DskipTests ${ALT_DEPLOYMENT_REPOSITORY}"
+            fi
+          fi
+        elif [ '${{ github.event_name }}' == 'push' ] || [ '${{ github.event_name }}' == 'workflow_dispatch' ]; then
+          if [ ! '${{ fromJSON(inputs.dsb-build-envs).caller-repo-is-on-default-branch }}' == 'true' ]; then
+            log-info "Maven release artifacts will not be deployed as current branch '${{ fromJSON(inputs.dsb-build-envs).caller-repo-calling-branch }}' is not the default of this repo."
+            exit 0
+          elif [ ! "$(get-val 'maven-build-project-deploy-release-artifacts')" == 'true' ]; then
+            log-info "Deployment of maven release artifacts not requested."
+            exit 0
+          else
+            log-info "Will deploy maven release artifacts as requested."
+            if has-field 'maven-build-project-deploy-release-version-command'; then
+              log-info "using maven version command from 'inputs.dsb-build-envs.maven-build-project-deploy-release-version-command'."
+              MVN_VERSION_CMD="$(get-val 'maven-build-project-deploy-release-version-command') -DnewVersion=${{ fromJSON(inputs.dsb-build-envs).application-version }} ${ALT_DEPLOYMENT_REPOSITORY}"
+            else
+              log-info "not setting version with maven as version was already set correctly in the build step."
+              MVN_VERSION_CMD=
+            fi
+            if has-field 'maven-build-project-deploy-release-deploy-command'; then
+              log-info "using maven deploy command from 'inputs.dsb-build-envs.maven-build-project-deploy-release-deploy-command'."
+              MVN_CMD="$(get-val 'maven-build-project-deploy-release-deploy-command') ${ALT_DEPLOYMENT_REPOSITORY}"
+            else
+              log-info "using default maven deploy command."
+              MVN_CMD="mvn -B --file ${POM_FILE} deploy -DskipTests ${ALT_DEPLOYMENT_REPOSITORY}"
+            fi
+          fi
+        else
+          log-error "unsupported github.event_name '${{ github.event_name }}' with github.event.action '${{ github.event.action }}'!"
+          exit 1
+        fi
+
+        # Load extra envs if any
+        EXTRA_ENVS=$(cat <<'EOF'
+        ${{ inputs.set-extra-envs }}
+        EOF
+        )
+        if [ ! -z "$EXTRA_ENVS" ]; then
+          echo "::group::build-dsb-maven-project: Deploy artifacts: extra environment variables"
+          JSON_FIELDS=$(echo ${EXTRA_ENVS} | jq -r '[keys[]] | join(" ")')
+          for JSON_FIELD in ${JSON_FIELDS}; do
+              JSON_VALUE=$(echo ${EXTRA_ENVS} | jq -r ".${JSON_FIELD}")
+              echo "Setting extra environment variable '${JSON_FIELD}'"
+              export "${JSON_FIELD}"="${JSON_VALUE}"
+          done
+          echo "::endgroup::"
+        fi
+
+        if [ -z "${MVN_VERSION_CMD}" ]; then
+          log-info "Project version already set by maven."
+        else
+          # Expand any bash variables in maven command string
+          MVN_VERSION_CMD=$(eval "echo $MVN_VERSION_CMD")
+          echo "::group::build-dsb-maven-project: Setting maven project version for deployment of artifacts"
+          log-info "command string: '${MVN_VERSION_CMD}'"
+          ${MVN_VERSION_CMD}
+          echo "::endgroup::"
+        fi
+
+        # Expand any bash variables in maven command string
+        MVN_CMD=$(eval "echo $MVN_CMD")
+        echo "::group::build-dsb-maven-project: Deploy artifacts: Invoke maven"
+        log-info "command string: '${MVN_CMD}'"
+        ${MVN_CMD}
+        echo "::endgroup::"
+      env:
+        DSB_GH_PACKAGES_REPO_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).github-repo-token }}
+        DSB_GH_PACKAGES_USER_NAME: ${{ github.actor }}

--- a/ci-cd/create-build-envs/action.yml
+++ b/ci-cd/create-build-envs/action.yml
@@ -252,11 +252,12 @@ runs:
           maven-build-project-arguments
           maven-build-project-command
           maven-build-project-deploy-release-artifacts
-          maven-build-project-deploy-release-version-command
           maven-build-project-deploy-release-deploy-command
+          maven-build-project-deploy-release-version-command
           maven-build-project-deploy-snapshot-artifacts
-          maven-build-project-deploy-snapshot-version-command
           maven-build-project-deploy-snapshot-deploy-command
+          maven-build-project-deploy-snapshot-version-command
+          maven-build-project-github-packages-enabled
           maven-build-project-goals
           maven-build-project-version-arguments
           maven-build-project-version-command


### PR DESCRIPTION
If maven-build-project-github-packages-enabled is set to true, the artifacts will also be deployed to Github Packages. The same logic as for deployment to Nexus is used.