### PR TITLE
Maven settings and deploy repos

### DIFF
--- a/.github/workflows/ci-cd-build-deploy-maven-lib.yml
+++ b/.github/workflows/ci-cd-build-deploy-maven-lib.yml
@@ -68,8 +68,9 @@ jobs:
         uses: dsb-norge/github-actions/ci-cd/create-build-envs@v2
         with:
           app-vars: ${{ toJSON(matrix.app-vars) }}
-          maven-repo-username: ${{ vars.ORG_MAVEN_REPO_USERNAME }}
-          maven-repo-token: ${{ secrets.ORG_MAVEN_REPO_TOKEN }}
+          github-json: ${{ toJSON(github) }}
+          secrets-json: ${{ toJSON(secrets) }}
+          vars-json: ${{ toJSON(vars) }}
           sonarqube-token: ${{ secrets.ORG_SONAR_TOKEN }}
           jasypt-password: ${{ secrets.ORG_JASYPT_LOCAL_ENCRYPTOR_PASSWORD }}
           github-repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -85,8 +85,9 @@ jobs:
         uses: dsb-norge/github-actions/ci-cd/create-build-envs@v2
         with:
           app-vars: ${{ toJSON(matrix.app-vars) }}
-          maven-repo-username: ${{ vars.ORG_MAVEN_REPO_USERNAME }}
-          maven-repo-token: ${{ secrets.ORG_MAVEN_REPO_TOKEN }}
+          github-json: ${{ toJSON(github) }}
+          secrets-json: ${{ toJSON(secrets) }}
+          vars-json: ${{ toJSON(vars) }}
           sonarqube-token: ${{ secrets.ORG_SONAR_TOKEN }}
           jasypt-password: ${{ secrets.ORG_JASYPT_LOCAL_ENCRYPTOR_PASSWORD }}
           acr-username: ${{ vars.ORG_AZURE_CONTAINER_REGISTRY_USER }}

--- a/.github/workflows/maven-versions-bumper.yml
+++ b/.github/workflows/maven-versions-bumper.yml
@@ -70,8 +70,9 @@ jobs:
         uses: dsb-norge/github-actions/ci-cd/create-build-envs@v2
         with:
           app-vars: ${{ toJSON(matrix.app-vars) }}
-          maven-repo-username: ${{ vars.ORG_MAVEN_REPO_USERNAME }}
-          maven-repo-token: ${{ secrets.ORG_MAVEN_REPO_TOKEN }}
+          github-json: ${{ toJSON(github) }}
+          secrets-json: ${{ toJSON(secrets) }}
+          vars-json: ${{ toJSON(vars) }}
 
       - name: "⚒ Spring Boot app: Run Maven command"
         id: maven-bump

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 
 # files from action test
 ci-cd/create-app-vars-matrix/_*
+ci-cd/create-build-envs/_*

--- a/ci-cd/build-maven-project/action.yml
+++ b/ci-cd/build-maven-project/action.yml
@@ -107,7 +107,6 @@ inputs:
         maven-build-project-deploy-snapshot-artifacts
         maven-build-project-deploy-snapshot-version-command
         maven-build-project-deploy-snapshot-deploy-command
-        maven-build-project-github-packages-enabled
     required: true
 
 runs:
@@ -118,21 +117,21 @@ runs:
       with:
         dsb-build-envs: ${{ inputs.dsb-build-envs }}
         require: |
+          acr-password
+          acr-username
           application-source-path
           application-version
-          java-distribution
-          java-version
-          maven-repo-pom-id
-          jasypt-password
-          github-repo-token
-          sonarqube-token
-          maven-repo-token
-          maven-repo-username
           caller-repo-calling-branch
           caller-repo-is-on-default-branch
           docker-image-registry
-          acr-username
-          acr-password
+          github-repo-token
+          jasypt-password
+          java-distribution
+          java-version
+          maven-build-project-deploy-to-repositories-yml
+          maven-extra-envs-from-github
+          maven-user-settings-repositories-yml
+          sonarqube-token
 
     # log into azure container registry (ACR) to enable maven to access internal images
     - uses: azure/docker-login@v1
@@ -144,27 +143,18 @@ runs:
     # locate pom.xml and define maven commands
     - id: mvn-cmd
       shell: bash
+      env:
+        BUILD_ENVS: "${{ inputs.dsb-build-envs }}"
       run: |
         # Locate pom.xml and define maven commands
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
 
         # Defaults
         MVN_VERSION_ARGUMENTS_DEFAULT='-B'
         MVN_VERSION_GOALS_DEFAULT='versions:set'
         MVN_ARGUMENTS_DEFAULT='-B'
         MVN_GOALS_DEFAULT='clean verify install org.sonarsource.scanner.maven:sonar-maven-plugin:sonar'
-
-        BUILD_ENVS=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs }}
-        EOF
-        )
-
-        # Helper functions
-        # Check if field exists in BUILD_ENVS safely
-        function has-field { if [[ "$(echo "${BUILD_ENVS}"| jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
-        # Get field value from BUILD_ENVS safely
-        function get-val { echo "${BUILD_ENVS}" | jq -r --arg name "$1" '.[$name]'; }
-        function log-info { echo "build-dsb-maven-project: $*"; }
-        function log-error { echo "ERROR: build-dsb-maven-project: $*"; }
 
         # Locate pom.xml
         POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}"
@@ -227,70 +217,60 @@ runs:
         log-info "Maven build command: '${MVN_CMD}'"
         echo "mvn-cmd=${MVN_CMD}" >> $GITHUB_OUTPUT
 
+    # configure maven settings
+    - uses: dsb-norge/github-actions/ci-cd/configure-maven-settings@v2
+      with:
+        user-settings-repositories-yml: ${{ fromJSON(inputs.dsb-build-envs).maven-user-settings-repositories-yml }}
+
     # set up JDK
     - uses: actions/setup-java@v3
       with:
         distribution: ${{ fromJSON(inputs.dsb-build-envs).java-distribution }}
         java-version: ${{ fromJSON(inputs.dsb-build-envs).java-version }}
-        server-id: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-pom-id }} # Value of the repository/id field of the pom.xml
-        # Jenkins user in repo.dsb.no. Pwd for login to repo.dsb.no found in keepass
-        server-username: DSB_MAVEN_REPO_USER_NAME
-        server-password: DSB_MAVEN_REPO_TOKEN
-        overwrite-settings: true
+        overwrite-settings: false # do not overwrite settings.xml from the configure-maven-settings action
 
     # invoke maven
     - shell: bash
-      run: |
-        # Define extra envs, if any, and invoke maven
-
-        EXTRA_ENVS=$(cat <<'EOF'
-        ${{ inputs.set-extra-envs }}
-        EOF
-        )
-        if [ ! -z "$EXTRA_ENVS" ]; then
-          echo "::group::build-dsb-maven-project: extra environment variables"
-          JSON_FIELDS=$(echo ${EXTRA_ENVS} | jq -r '[keys[]] | join(" ")')
-          for JSON_FIELD in ${JSON_FIELDS}; do
-              JSON_VALUE=$(echo ${EXTRA_ENVS} | jq -r ".${JSON_FIELD}")
-              echo "Setting extra environment variable '${JSON_FIELD}'"
-              export "${JSON_FIELD}"="${JSON_VALUE}"
-          done
-          echo "::endgroup::"
-        fi
-
-        echo "::group::build-dsb-maven-project: Setting maven project version"
-        echo "build-dsb-maven-project: command string: '${{ steps.mvn-cmd.outputs.mvn-version-cmd }}'"
-        ${{ steps.mvn-cmd.outputs.mvn-version-cmd }}
-        echo "::endgroup::"
-
-        echo "::group::build-dsb-maven-project: Invoke maven with goals"
-        echo "build-dsb-maven-project: command string: '${{ steps.mvn-cmd.outputs.mvn-cmd }}'"
-        ${{ steps.mvn-cmd.outputs.mvn-cmd }}
-        echo "::endgroup::"
       env:
+        EXTRA_ENVS: "${{ inputs.set-extra-envs }}"
+        EXTRA_ENVS_FROM_GH: "${{ fromJSON(inputs.dsb-build-envs).maven-extra-envs-from-github }}"
         JASYPT_LOCAL_ENCRYPTOR_PASSWORD: ${{ fromJSON(inputs.dsb-build-envs).jasypt-password }}
         GITHUB_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).github-repo-token }} # Needed for Sonar to get PR information, if any
         SONAR_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).sonarqube-token }}
-        DSB_MAVEN_REPO_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-token }}
-        DSB_MAVEN_REPO_USER_NAME: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-username }}
+      run: |
+        # Define extra envs, if any, and invoke maven
 
-    # deploy maven build artifacts to Nexus
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        # export extra envs
+        export-extra-envs "general" "${EXTRA_ENVS}"
+        export-extra-envs "from github" "${EXTRA_ENVS_FROM_GH}"
+
+        start-group "Setting maven project version"
+        log-info "command string: '${{ steps.mvn-cmd.outputs.mvn-version-cmd }}'"
+        ${{ steps.mvn-cmd.outputs.mvn-version-cmd }}
+        end-group
+
+        start-group "Invoke maven with goals"
+        log-info "command string: '${{ steps.mvn-cmd.outputs.mvn-cmd }}'"
+        ${{ steps.mvn-cmd.outputs.mvn-cmd }}
+        end-group
+
+        # remove extra envs
+        unset-extra-envs "general" "${EXTRA_ENVS}"
+        unset-extra-envs "from github" "${EXTRA_ENVS_FROM_GH}"
+
+    # deploy maven build artifacts to configured maven deployment repos
     - shell: bash
+      env:
+        BUILD_ENVS: "${{ inputs.dsb-build-envs }}"
+        EXTRA_ENVS: "${{ inputs.set-extra-envs }}"
+        EXTRA_ENVS_FROM_GH: "${{ fromJSON(inputs.dsb-build-envs).maven-extra-envs-from-github }}"
+        DEPLOY_TO_REPOS_YML: "${{ fromJSON(inputs.dsb-build-envs).maven-build-project-deploy-to-repositories-yml }}"
       run: |
         # Use maven to deploy artifacts when allowed and requested
 
-        BUILD_ENVS=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs }}
-        EOF
-        )
-
-        # Helper functions
-        # Check if field exists in BUILD_ENVS safely
-        function has-field { if [[ "$(echo "${BUILD_ENVS}"| jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
-        # Get field value from BUILD_ENVS safely
-        function get-val { echo "${BUILD_ENVS}" | jq -r --arg name "$1" '.[$name]'; }
-        function log-info { echo "build-dsb-maven-project: Deploy artifacts to Nexus: $*"; }
-        function log-error { echo "ERROR: build-dsb-maven-project: Deploy artifacts to Nexus: $*"; }
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
 
         # Locate pom.xml
         POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}"
@@ -301,6 +281,10 @@ runs:
 
         # Determine if we are deploying and with what commands
         if [ '${{ github.event_name }}' == 'pull_request' ]; then
+
+          # it's snapshot, record this for later
+          DEPLOY_TYPE='snapshot'
+
           if [ '${{ github.event.action }}' == 'closed' ]; then
             log-info "Maven snapshot artifacts will not be deployed when closing PR."
             exit 0
@@ -313,7 +297,7 @@ runs:
               log-info "using maven version command from 'inputs.dsb-build-envs.maven-build-project-deploy-snapshot-version-command'."
               MVN_VERSION_CMD="$(get-val 'maven-build-project-deploy-snapshot-version-command') -DnewVersion=pr-${{ github.event.number }}-SNAPSHOT"
             else
-              log-info "using default maven version command."
+              log-info "  d."
               MVN_VERSION_CMD="mvn -B --file ${POM_FILE} versions:set -DnewVersion=pr-${{ github.event.number }}-SNAPSHOT"
             fi
             if has-field 'maven-build-project-deploy-snapshot-deploy-command'; then
@@ -325,6 +309,10 @@ runs:
             fi
           fi
         elif [ '${{ github.event_name }}' == 'push' ] || [ '${{ github.event_name }}' == 'workflow_dispatch' ]; then
+
+          # it's release, record this for later
+          DEPLOY_TYPE='release'
+
           if [ ! '${{ fromJSON(inputs.dsb-build-envs).caller-repo-is-on-default-branch }}' == 'true' ]; then
             log-info "Maven release artifacts will not be deployed as current branch '${{ fromJSON(inputs.dsb-build-envs).caller-repo-calling-branch }}' is not the default of this repo."
             exit 0
@@ -353,173 +341,48 @@ runs:
           exit 1
         fi
 
-        # Load extra envs if any
-        EXTRA_ENVS=$(cat <<'EOF'
-        ${{ inputs.set-extra-envs }}
-        EOF
-        )
-        if [ ! -z "$EXTRA_ENVS" ]; then
-          echo "::group::build-dsb-maven-project: Deploy artifacts: extra environment variables"
-          JSON_FIELDS=$(echo ${EXTRA_ENVS} | jq -r '[keys[]] | join(" ")')
-          for JSON_FIELD in ${JSON_FIELDS}; do
-              JSON_VALUE=$(echo ${EXTRA_ENVS} | jq -r ".${JSON_FIELD}")
-              echo "Setting extra environment variable '${JSON_FIELD}'"
-              export "${JSON_FIELD}"="${JSON_VALUE}"
-          done
-          echo "::endgroup::"
-        fi
+        # export extra envs
+        export-extra-envs "general" "${EXTRA_ENVS}"
+        export-extra-envs "from github" "${EXTRA_ENVS_FROM_GH}"
 
         if [ -z "${MVN_VERSION_CMD}" ]; then
           log-info "Project version already set by maven."
         else
           # Expand any bash variables in maven command string
           MVN_VERSION_CMD=$(eval "echo $MVN_VERSION_CMD")
-          echo "::group::build-dsb-maven-project: Setting maven project version for deployment of artifacts"
+          start-group "Setting maven project version for deployment of artifacts"
           log-info "command string: '${MVN_VERSION_CMD}'"
           ${MVN_VERSION_CMD}
-          echo "::endgroup::"
+          end-group
         fi
 
         # Expand any bash variables in maven command string
         MVN_CMD=$(eval "echo $MVN_CMD")
-        echo "::group::build-dsb-maven-project: Deploy artifacts: Invoke maven"
-        log-info "command string: '${MVN_CMD}'"
-        ${MVN_CMD}
-        echo "::endgroup::"
-      env:
-        DSB_MAVEN_REPO_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-token }}
-        DSB_MAVEN_REPO_USER_NAME: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-username }}
 
-    # create a new settings.xml with credentials for Github Packages
-    - uses: actions/setup-java@v3
-      with:
-        distribution: ${{ fromJSON(inputs.dsb-build-envs).java-distribution }}
-        java-version: ${{ fromJSON(inputs.dsb-build-envs).java-version }}
-        server-id: github-dsb-norge # Value of the repository/id field of the pom.xml
-        server-username: DSB_GH_PACKAGES_USER_NAME
-        server-password: DSB_GH_PACKAGES_REPO_TOKEN
-        overwrite-settings: true
-
-    # deploy maven build artifacts to Github Packages
-    - shell: bash
-      run: |
-        # Use maven to deploy artifacts when allowed and requested
-
-        BUILD_ENVS=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs }}
-        EOF
+        log-info "Parse maven deployment repos ..."
+        # this creates an array with strings compatible with maven deploy mojo 'altDeploymentRepository' parameter
+        # ref. https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html
+        export REPO_YML_KEY="${DEPLOY_TYPE}-repositories" # 'export' to make available to yq
+        readarray -t DEPLOY_TO_REPOS_ARR < <(
+          echo "${DEPLOY_TO_REPOS_YML}" |
+            yq eval '
+              .[strenv(REPO_YML_KEY)] |
+              map (
+                (. | key) as $key |
+                [$key, .] | join("::default::")
+              ).[]'
         )
+        unset REPO_YML_KEY
 
-        # Helper functions
-        # Check if field exists in BUILD_ENVS safely
-        function has-field { if [[ "$(echo "${BUILD_ENVS}"| jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
-        # Get field value from BUILD_ENVS safely
-        function get-val { echo "${BUILD_ENVS}" | jq -r --arg name "$1" '.[$name]'; }
-        function log-info { echo "build-dsb-maven-project: Deploy artifacts to Github Packages: $*"; }
-        function log-error { echo "ERROR: build-dsb-maven-project: Deploy artifacts to Github Packages: $*"; }
+        log-info "Deploying to ${#DEPLOY_TO_REPOS_ARR[@]} repo(s):"
+        for DEPLOY_TO_REPO in "${DEPLOY_TO_REPOS_ARR[@]}"; do
+          start-group "Deploy artifacts to '${DEPLOY_TO_REPO%::default*}'" # funky syntax removes everything from '::default'
+          MVN_REPO_ARG="-DaltDeploymentRepository=${DEPLOY_TO_REPO}"
+          log-info "command string: '${MVN_CMD} ${MVN_REPO_ARG}'"
+          ${MVN_CMD} ${MVN_REPO_ARG}
+          end-group
+        done
 
-        if [ "$(get-val 'maven-build-project-github-packages-enabled')" == 'false' ]; then
-            log-info "Maven artifacts will not be deployed to Github Packages as 'maven-build-project-github-packages-enabled' is set to 'false'."
-            exit 0
-        fi
-
-        # Locate pom.xml
-        POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}"
-        [ ! -f "${POM_FILE}" ] && POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}/pom.xml"
-        [ ! -f "${POM_FILE}" ] && \
-          log-error "Cannot find pom.xml. Both '${{ fromJSON(inputs.dsb-build-envs).application-source-path }}' and '${POM_FILE}' does not exist!" && \
-          exit 1
-
-        ALT_DEPLOYMENT_REPOSITORY="-DaltDeploymentRepository=github-dsb-norge::default::https://maven.pkg.github.com/${{ github.repository }}"
-        log-info "ALT_DEPLOYMENT_REPOSITORY is now set to '${ALT_DEPLOYMENT_REPOSITORY}'"
-
-        # Determine if we are deploying and with what commands
-        if [ '${{ github.event_name }}' == 'pull_request' ]; then
-          if [ '${{ github.event.action }}' == 'closed' ]; then
-            log-info "Maven snapshot artifacts will not be deployed when closing PR."
-            exit 0
-          elif [ ! "$(get-val 'maven-build-project-deploy-snapshot-artifacts')" == 'true' ]; then
-            log-info "Deployment of maven snapshot artifacts not requested."
-            exit 0
-          else
-            log-info "Will deploy maven snapshot artifacts as requested."
-            if has-field 'maven-build-project-deploy-snapshot-version-command'; then
-              log-info "using maven version command from 'inputs.dsb-build-envs.maven-build-project-deploy-snapshot-version-command'."
-              MVN_VERSION_CMD="$(get-val 'maven-build-project-deploy-snapshot-version-command') -DnewVersion=pr-${{ github.event.number }}-SNAPSHOT ${ALT_DEPLOYMENT_REPOSITORY}"
-            else
-              log-info "using default maven version command."
-              MVN_VERSION_CMD="mvn -B --file ${POM_FILE} versions:set -DnewVersion=pr-${{ github.event.number }}-SNAPSHOT ${ALT_DEPLOYMENT_REPOSITORY}"
-            fi
-            if has-field 'maven-build-project-deploy-snapshot-deploy-command'; then
-              log-info "using maven deploy command from 'inputs.dsb-build-envs.maven-build-project-deploy-snapshot-deploy-command'."
-              MVN_CMD="$(get-val 'maven-build-project-deploy-snapshot-deploy-command')"
-            else
-              log-info "using default maven deploy command."
-              MVN_CMD="mvn -B --file ${POM_FILE} deploy -DskipTests ${ALT_DEPLOYMENT_REPOSITORY}"
-            fi
-          fi
-        elif [ '${{ github.event_name }}' == 'push' ] || [ '${{ github.event_name }}' == 'workflow_dispatch' ]; then
-          if [ ! '${{ fromJSON(inputs.dsb-build-envs).caller-repo-is-on-default-branch }}' == 'true' ]; then
-            log-info "Maven release artifacts will not be deployed as current branch '${{ fromJSON(inputs.dsb-build-envs).caller-repo-calling-branch }}' is not the default of this repo."
-            exit 0
-          elif [ ! "$(get-val 'maven-build-project-deploy-release-artifacts')" == 'true' ]; then
-            log-info "Deployment of maven release artifacts not requested."
-            exit 0
-          else
-            log-info "Will deploy maven release artifacts as requested."
-            if has-field 'maven-build-project-deploy-release-version-command'; then
-              log-info "using maven version command from 'inputs.dsb-build-envs.maven-build-project-deploy-release-version-command'."
-              MVN_VERSION_CMD="$(get-val 'maven-build-project-deploy-release-version-command') -DnewVersion=${{ fromJSON(inputs.dsb-build-envs).application-version }} ${ALT_DEPLOYMENT_REPOSITORY}"
-            else
-              log-info "not setting version with maven as version was already set correctly in the build step."
-              MVN_VERSION_CMD=
-            fi
-            if has-field 'maven-build-project-deploy-release-deploy-command'; then
-              log-info "using maven deploy command from 'inputs.dsb-build-envs.maven-build-project-deploy-release-deploy-command'."
-              MVN_CMD="$(get-val 'maven-build-project-deploy-release-deploy-command') ${ALT_DEPLOYMENT_REPOSITORY}"
-            else
-              log-info "using default maven deploy command."
-              MVN_CMD="mvn -B --file ${POM_FILE} deploy -DskipTests ${ALT_DEPLOYMENT_REPOSITORY}"
-            fi
-          fi
-        else
-          log-error "unsupported github.event_name '${{ github.event_name }}' with github.event.action '${{ github.event.action }}'!"
-          exit 1
-        fi
-
-        # Load extra envs if any
-        EXTRA_ENVS=$(cat <<'EOF'
-        ${{ inputs.set-extra-envs }}
-        EOF
-        )
-        if [ ! -z "$EXTRA_ENVS" ]; then
-          echo "::group::build-dsb-maven-project: Deploy artifacts: extra environment variables"
-          JSON_FIELDS=$(echo ${EXTRA_ENVS} | jq -r '[keys[]] | join(" ")')
-          for JSON_FIELD in ${JSON_FIELDS}; do
-              JSON_VALUE=$(echo ${EXTRA_ENVS} | jq -r ".${JSON_FIELD}")
-              echo "Setting extra environment variable '${JSON_FIELD}'"
-              export "${JSON_FIELD}"="${JSON_VALUE}"
-          done
-          echo "::endgroup::"
-        fi
-
-        if [ -z "${MVN_VERSION_CMD}" ]; then
-          log-info "Project version already set by maven."
-        else
-          # Expand any bash variables in maven command string
-          MVN_VERSION_CMD=$(eval "echo $MVN_VERSION_CMD")
-          echo "::group::build-dsb-maven-project: Setting maven project version for deployment of artifacts"
-          log-info "command string: '${MVN_VERSION_CMD}'"
-          ${MVN_VERSION_CMD}
-          echo "::endgroup::"
-        fi
-
-        # Expand any bash variables in maven command string
-        MVN_CMD=$(eval "echo $MVN_CMD")
-        echo "::group::build-dsb-maven-project: Deploy artifacts: Invoke maven"
-        log-info "command string: '${MVN_CMD}'"
-        ${MVN_CMD}
-        echo "::endgroup::"
-      env:
-        DSB_GH_PACKAGES_REPO_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).github-repo-token }}
-        DSB_GH_PACKAGES_USER_NAME: ${{ github.actor }}
+        # remove extra envs
+        unset-extra-envs "general" "${EXTRA_ENVS}"
+        unset-extra-envs "from github" "${EXTRA_ENVS_FROM_GH}"

--- a/ci-cd/build-maven-project/helpers.sh
+++ b/ci-cd/build-maven-project/helpers.sh
@@ -1,0 +1,70 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name='build-maven-project'
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+
+
+# Helper functions for working with dsb build envs JSONs
+# ======================================================
+
+# Check if field exists in BUILD_ENVS safely
+function has-field { if [[ "$(echo "${BUILD_ENVS}"| jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
+
+# Get field value from BUILD_ENVS safely
+function get-val { echo "${BUILD_ENVS}" | jq -r --arg name "$1" '.[$name]'; }
+
+
+# Helper functions for working with dsb build envs JSONs
+# ======================================================
+
+function export-extra-envs {
+  _extra-envs 'export' "$@"
+}
+function unset-extra-envs {
+  _extra-envs 'unset' "$@"
+}
+function _extra-envs {
+  local op="${1}"
+  local envs_name="${2}"
+  local envs_json="${3}"
+  local env_names env_name env_value
+
+  if [ "${op}" == "export" ]; then
+    if [ -z "${envs_json}" ] ; then
+      log-info "No '${envs_name}' extra environment variables to export."
+    else
+      start-group "'${envs_name}' extra environment variables exported"
+      env_names=$(echo ${envs_json} | jq -r '[keys[]] | join(" ")')
+      for env_name in ${env_names}; do
+          env_value=$(echo ${envs_json} | jq -r ".${env_name}")
+          echo " - '${env_name}' with value length ${#env_value}"
+          export "${env_name}"="${env_value}"
+      done
+      end-group
+    fi
+  fi
+  if [ "${op}" == "unset" ] && [ ! -z "${envs_json}" ]; then
+      log-info "Removing '${envs_name}' extra environment variables ..."
+      for env_name in ${env_names}; do
+          unset "${env_name}"
+      done
+  fi
+}
+
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/ci-cd/build-nodejs-project/action.yml
+++ b/ci-cd/build-nodejs-project/action.yml
@@ -34,13 +34,10 @@ runs:
 
     # npm install, build
     - shell: bash
+      env:
+        BUILD_ENVS: "${{ inputs.dsb-build-envs }}"
       run: |
         # npm install, build with support for additional custom commands
-
-        BUILD_ENVS=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs }}
-        EOF
-        )
 
         # Helper functions
         # Check if field exists in BUILD_ENVS safely

--- a/ci-cd/build-spring-boot-image/action.yml
+++ b/ci-cd/build-spring-boot-image/action.yml
@@ -149,6 +149,8 @@ runs:
     # define maven commands
     - id: mvn-cmd
       shell: bash
+      env:
+        BUILD_ENVS: "${{ inputs.dsb-build-envs }}"
       run: |
         # Define maven commands
 
@@ -162,11 +164,6 @@ runs:
         MVN_ARGUMENTS_DEFAULT='-B -DskipTests'
         MVN_GOALS_DEFAULT='spring-boot:build-image'
         MVN_IMAGE_REF_ARGUMENT="-Dspring-boot.build-image.imageName=${LOCAL_IMAGE_ID}"
-
-        BUILD_ENVS=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs }}
-        EOF
-        )
 
         # Helper functions
         # Check if field exists in BUILD_ENVS safely
@@ -237,13 +234,10 @@ runs:
     # filter dsb-build-envs
     - id: filter-build-envs
       shell: bash
+      env:
+        BUILD_ENVS: "${{ inputs.dsb-build-envs }}"
       run: |
         # Make sure build-maven-project action does not attempt to deploy maven artifacts
-
-        BUILD_ENVS=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs }}
-        EOF
-        )
 
         # Helper functions
         # Add/overwrite fields in BUILD_ENVS safely

--- a/ci-cd/collect-build-envs/action.yml
+++ b/ci-cd/collect-build-envs/action.yml
@@ -1,6 +1,6 @@
 name: 'Collect common DSB CI/CD variables stored as github workflow artifacts'
 description: |
-  This will collect common DSB build environment variables from previously completed paralell build jobs.
+  This will collect common DSB build environment variables from previously completed parallel build jobs.
   Build-envs for each job are uploaded as github workflow artifacts in JSON format by the create-build-envs action.
   This action pulls down the JSON files, merges them and returns them as output.
 author: 'Peder Schmedling'

--- a/ci-cd/configure-maven-settings/action.yml
+++ b/ci-cd/configure-maven-settings/action.yml
@@ -1,0 +1,184 @@
+name: "Create common DSB CI/CD variables"
+description: |
+  This action overwrites the maven user settings (settings.xml) in the current users home directory with one generated
+  from the input supplied to this action. And returns the path to the settings.xml file.
+
+  The action will create a settings.xml with one active profile named 'hybrid', and populate the profile with <repositories>
+  based on the given input. Additionally the <servers> block of the settings.xml will be populated based on the given input.
+
+  ref. https://maven.apache.org/settings.html#settings-reference
+
+  Example, given the following input:
+  ```yml
+    repositories:
+      - id: "server1-id"
+        name: "Friendly name of server 1"
+        url: "https://maven.pkg.github.com/my-org/my-repo"
+        username: "repo reader"
+        password: "secrets go here"
+      - id: "server2-id"
+        name: "Friendly name of server 2"
+        url: "https://repo.tld.zip/maven2-repo"
+        username: "${env.REPO_USERNAME}"        <-- maven supports populating from env
+        password: "${env.DSB_PASSWORD}"
+  ```
+
+  The following xml will be written to "${HOME}/.m2/settings.xml":
+  ```xml
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+      <activeProfiles>
+        <activeProfile>hybrid</activeProfile>
+      </activeProfiles>
+      <profiles>
+        <profile>
+          <id>hybrid</id>
+          <repositories>
+            <repository>
+              <id>server1-id</id>
+              <name>Friendly name of server 1</name>
+              <releases>
+                <checksumPolicy>fail</checksumPolicy>
+                <enabled>true</enabled>
+              </releases>
+              <snapshots>
+                <checksumPolicy>fail</checksumPolicy>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+              </snapshots>
+              <url>https://maven.pkg.github.com/my-org/my-repo</url>
+            </repository>
+            <repository>
+              <id>server2-id</id>
+              <name>Friendly name of server 2</name>
+              <releases>
+                <checksumPolicy>fail</checksumPolicy>
+                <enabled>true</enabled>
+              </releases>
+              <snapshots>
+                <checksumPolicy>fail</checksumPolicy>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+              </snapshots>
+              <url>https://repo.tld.zip/maven2-repo</url>
+            </repository>
+          </repositories>
+        </profile>
+      </profiles>
+      <servers>
+        <server>
+          <id>server1-id</id>
+          <username>repo reader</username>
+          <password>secrets go here</password>
+        </server>
+        <server>
+          <id>server2-id</id>
+          <username>${env.REPO_USERNAME}</username>
+          <password>${env.DSB_PASSWORD}</password>
+        </server>
+      </servers>
+    </settings>
+  ```
+
+author: "Peder Schmedling"
+inputs:
+  user-settings-repositories-yml:
+    description: |
+      A YAML list (as string) with information about maven repositories that will be used to create a maven settings.xml.
+      The order of the repositories dictates in what order maven will search the repos for artifacts.
+      See action description for example input.
+    required: true
+outputs:
+  settings-xml-path:
+    description: "The path to the maven settings.xml file"
+    value: ${{ steps.write.outputs.settings-xml-path }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: write
+      shell: bash
+      env:
+        SETTINGS_XML_TEMPLATE_PATH: "${{ github.action_path }}/settings-template.xml"
+        USER_SETTINGS_REPOSITORIES_YML: "${{ inputs.user-settings-repositories-yml }}"
+      run: |
+        # write settings.xml
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        # hardcoded path to settings.xml
+        SETTINGS_XML_PATH="${HOME}/.m2/settings.xml"
+
+        # tell github to mask the password in case they end up in the log
+        readarray -t PASSWORDS_IN_YML < <(
+          echo "${USER_SETTINGS_REPOSITORIES_YML}" |
+            yq eval '
+              .repositories.[].password
+          '
+        )
+        for PASSWORD in "${PASSWORDS_IN_YML[@]}"; do
+          mask-value "${PASSWORD}"
+        done
+
+        if [ -f "${SETTINGS_XML_TEMPLATE_PATH}" ]; then
+          log-info "template file located at '${SETTINGS_XML_TEMPLATE_PATH}'"
+        else
+          log-error "the template file was not found at '${SETTINGS_XML_TEMPLATE_PATH}'"
+          exit 1
+        fi
+
+        log-info 'generating <repositories> section of maven user settings file ...'
+        REPOSITORIES_XML=$(
+          echo "${USER_SETTINGS_REPOSITORIES_YML}" |
+            yq --input-format yaml --output-format xml eval '
+            { "settings": { "profiles": { "profile": { "repositories": { "repository": (
+              { "releases" : { "enabled" : "true", "checksumPolicy" : "fail" }, "snapshots" : { "enabled" : "true", "checksumPolicy" : "fail", "updatePolicy" : "always" } } as $defaults |
+              .repositories |
+              map(
+                $defaults * .
+              ) |
+              map(
+                . | with_entries(select( .key | test("^id$|^name$|^url$|^releases$|^snapshots$") ))
+              ) |
+              sort_keys(..)
+            )}}}}}
+          '
+        )
+
+        log-info 'merging <repositories> section into settings template file ...'
+        echo "${REPOSITORIES_XML}" |
+          yq --input-format xml --output-format xml --inplace eval-all \
+            --expression 'select(fileIndex == 0) * select(fileIndex == 1)' \
+            "${SETTINGS_XML_TEMPLATE_PATH}" -
+
+        log-info 'generating <servers> section of maven user settings file ...'
+        SERVERS_XML=$(
+          echo "${USER_SETTINGS_REPOSITORIES_YML}" |
+            yq --input-format yaml --output-format xml eval '
+            { "settings": { "servers": { "server": (
+              .repositories |
+              map(
+                . | with_entries(select( .key | test("id|username|password") ))
+              )
+            )}}}
+          '
+        )
+
+        log-info 'merging <servers> section into settings template file ...'
+        echo "${SERVERS_XML}" |
+          yq --input-format xml --output-format xml --inplace eval-all \
+            --expression 'select(fileIndex == 0) * select(fileIndex == 1)' \
+            "${SETTINGS_XML_TEMPLATE_PATH}" -
+
+        log-multiline "final settings.xml file" "$(cat ${SETTINGS_XML_TEMPLATE_PATH})"
+
+        if [ -f "${SETTINGS_XML_PATH}" ]; then
+          log-info "overwriting existing maven user settings file at '${SETTINGS_XML_PATH}'"
+        else
+          log-info "installing user settings template file to '${SETTINGS_XML_PATH}' ..."
+        fi
+        mkdir --parents "$(dirname "${SETTINGS_XML_PATH}")"
+        cp --force "${SETTINGS_XML_TEMPLATE_PATH}" "${SETTINGS_XML_PATH}"
+
+        echo "settings-xml-path=${SETTINGS_XML_PATH}" >> $GITHUB_OUTPUT

--- a/ci-cd/configure-maven-settings/helpers.sh
+++ b/ci-cd/configure-maven-settings/helpers.sh
@@ -1,0 +1,21 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name='configure-maven-settings'
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/ci-cd/configure-maven-settings/settings-template.xml
+++ b/ci-cd/configure-maven-settings/settings-template.xml
@@ -1,0 +1,18 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <activeProfiles>
+        <activeProfile>hybrid</activeProfile>
+    </activeProfiles>
+
+    <profiles>
+        <profile>
+            <id>hybrid</id>
+            <repositories/>
+        </profile>
+    </profiles>
+
+    <servers/>
+
+</settings>

--- a/ci-cd/create-app-vars-matrix/action.yml
+++ b/ci-cd/create-app-vars-matrix/action.yml
@@ -20,7 +20,7 @@ author: 'Peder Schmedling'
 inputs:
   apps:
     description: |
-      YAML list (as sting) with specifications of applications to build and/or deploy.
+      YAML list (as string) with specifications of applications to build and/or deploy.
       Required fields are:
         - application-name        - string
       For optional fields see possible inputs to the create-build-envs action.
@@ -40,9 +40,7 @@ runs:
       run: |
         # Convert app vars yaml to JSON
 
-        action_helpers_file="${{ github.action_path }}/helpers.sh"
-        echo -e "create-app-vars-matrix: Loading helper functions from '${action_helpers_file}' ..."
-        set -o allexport; source "${action_helpers_file}"; set +o allexport;
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
 
         # Log given yaml
         YAML_CONFIG=$(cat <<'EOF'
@@ -72,9 +70,7 @@ runs:
       run: |
         # Validate given app vars structure
 
-        action_helpers_file="${{ github.action_path }}/helpers.sh"
-        echo -e "create-app-vars-matrix: Loading helper functions from '${action_helpers_file}' ..."
-        set -o allexport; source "${action_helpers_file}"; set +o allexport;
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
 
         # Load and log app vars
         JSON_CONFIG=$(cat <<'EOF'
@@ -105,9 +101,7 @@ runs:
       run: |
         # Set application type where not explicitly defined
 
-        action_helpers_file="${{ github.action_path }}/helpers.sh"
-        echo -e "create-app-vars-matrix: Loading helper functions from '${action_helpers_file}' ..."
-        set -o allexport; source "${action_helpers_file}"; set +o allexport;
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
 
         # Load and log app vars
         IN_JSON=$(cat <<'EOF'
@@ -167,9 +161,7 @@ runs:
       run: |
         # Attempt to read application metadata from pom.xml/package.json for fields that are not explicitly defined in input
 
-        action_helpers_file="${{ github.action_path }}/helpers.sh"
-        echo -e "create-app-vars-matrix: Loading helper functions from '${action_helpers_file}' ..."
-        set -o allexport; source "${action_helpers_file}"; set +o allexport;
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
 
         # Load and log app vars
         IN_JSON=$(cat <<'EOF'
@@ -265,9 +257,7 @@ runs:
       run: |
         # Validate app vars structure, required fields and allowed values
 
-        action_helpers_file="${{ github.action_path }}/helpers.sh"
-        echo -e "create-app-vars-matrix: Loading helper functions from '${action_helpers_file}' ..."
-        set -o allexport; source "${action_helpers_file}"; set +o allexport;
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
 
         # Load and log app vars
         JSON_CONFIG=$(cat <<'EOF'
@@ -329,9 +319,7 @@ runs:
       run: |
         # Add additional dynamic app vars
 
-        action_helpers_file="${{ github.action_path }}/helpers.sh"
-        echo -e "create-app-vars-matrix: Loading helper functions from '${action_helpers_file}' ..."
-        set -o allexport; source "${action_helpers_file}"; set +o allexport;
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
 
         # Load and log app vars
         IN_JSON=$(cat <<'EOF'
@@ -380,9 +368,7 @@ runs:
       run: |
         # Create app vars matrix
 
-        action_helpers_file="${{ github.action_path }}/helpers.sh"
-        echo -e "create-app-vars-matrix: Loading helper functions from '${action_helpers_file}' ..."
-        set -o allexport; source "${action_helpers_file}"; set +o allexport;
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
 
         # Load and log app vars
         IN_JSON=$(cat <<'EOF'

--- a/ci-cd/create-app-vars-matrix/helpers.sh
+++ b/ci-cd/create-app-vars-matrix/helpers.sh
@@ -27,4 +27,4 @@ function fail-field {
   echo "::endgroup::"
 }
 
-log-info "'helpers.sh' loaded."
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/ci-cd/create-app-vars-matrix/test_action_source.sh
+++ b/ci-cd/create-app-vars-matrix/test_action_source.sh
@@ -10,7 +10,19 @@ this_script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 action_def_file="${this_script_dir}/action.yml"
 
 # load test runner code
-source "${this_script_dir}/test_action_source_helpers.sh"
+source "${this_script_dir}/test_action_source_helpers.sh" $*
+
+if [ "${1-}" == "clean" ]; then
+  del_files=$(find "${this_script_dir}" -name '_*' -print | sort)
+  if [ ! -z "${del_files}" ]; then
+    echo "deleting these:"
+    echo "${del_files}" | xargs realpath --relative-to=$(pwd)
+    echo "${del_files}" | xargs rm
+  else
+    echo "nothing to delete"
+  fi
+  exit 0
+fi
 
 # run tests
 should_pass_test 'test_input_minimal' "${action_def_file}" "${this_script_dir}"

--- a/ci-cd/create-app-vars-matrix/test_input_happy_day.yml
+++ b/ci-cd/create-app-vars-matrix/test_input_happy_day.yml
@@ -1,7 +1,7 @@
 #
 # Used for testing this actions code, see test_action_source.sh
 #
-- application-name: eksplosiv-api
+- application-name: app-name
   application-source-path: ../eksplosiv-org/backend
   maven-build-project-deploy-release-artifacts: true
   maven-build-project-deploy-snapshot-artifacts: true
@@ -20,24 +20,24 @@
   application-source-path: ../eksplosiv-org//frontend
   nodejs-version: "18"
   nodejs-build-project-custom-command-pre-npm-run-build: npm exec vue-demi-fix --prefix ./node_modules/pinia/node_modules/vue-demi/
-  pr-deploy-comment-additional-text: Available at https://pr-719.dev.eksplosiver.no/
+  pr-deploy-comment-additional-text: Available at https://pr-719.dev.tld.zip/
   pr-deploy-additional-helm-values:
     parameters:
-      dsb-nginx-frontend.config.LOC_API_PROXY_PASS_HOST: "http://eksplosiv-api-pr-719.eksplosiv-api-pr-719.svc.cluster.local:8080"
-      dsb-nginx-frontend.ingress_host: "pr-719.dev.eksplosiver.no"
+      dsb-nginx-frontend.config.LOC_API_PROXY_PASS_HOST: "http://app-name-pr-719.app-name-pr-719.svc.cluster.local:8080"
+      dsb-nginx-frontend.ingress_host: "pr-719.dev.tld.zip"
 - application-name: eksplosiv-permitchecker
   application-source-path: ../eksplosiv-org//permitchecker
   nodejs-version: "18"
-  pr-deploy-comment-additional-text: Available at https://pr-719-motta.dev.eksplosiver.no/
+  pr-deploy-comment-additional-text: Available at https://pr-719-motta.dev.tld.zip/
   pr-deploy-additional-helm-values:
     parameters:
-      dsb-nginx-frontend.config.LOC_API_PROXY_PASS_HOST: "http://eksplosiv-api-pr-719.eksplosiv-api-pr-719.svc.cluster.local:8080"
-      dsb-nginx-frontend.ingress_host: "pr-719-motta.dev.eksplosiver.no"
+      dsb-nginx-frontend.config.LOC_API_PROXY_PASS_HOST: "http://app-name-pr-719.app-name-pr-719.svc.cluster.local:8080"
+      dsb-nginx-frontend.ingress_host: "pr-719-motta.dev.tld.zip"
 - application-name: eksplosiv-saksbehandler
   application-source-path: ../eksplosiv-org//saksbehandler
   nodejs-version: "18"
-  pr-deploy-comment-additional-text: Available at https://pr-719-saksbehandler.dev.eksplosiver.no/
+  pr-deploy-comment-additional-text: Available at https://pr-719-saksbehandler.dev.tld.zip/
   pr-deploy-additional-helm-values:
     parameters:
-      dsb-nginx-frontend.config.LOC_API_PROXY_PASS_HOST: "http://eksplosiv-api-pr-719.eksplosiv-api-pr-719.svc.cluster.local:8080"
-      dsb-nginx-frontend.ingress_host: "pr-719-saksbehandler.dev.eksplosiver.no"
+      dsb-nginx-frontend.config.LOC_API_PROXY_PASS_HOST: "http://app-name-pr-719.app-name-pr-719.svc.cluster.local:8080"
+      dsb-nginx-frontend.ingress_host: "pr-719-saksbehandler.dev.tld.zip"

--- a/ci-cd/create-build-envs/action.yml
+++ b/ci-cd/create-build-envs/action.yml
@@ -1,24 +1,33 @@
-name: 'Create common DSB CI/CD variables'
+name: "Create common DSB CI/CD variables"
 description: |
   Given the required input this action returns common DSB build environment variables with values.
   Common DSB build environment variables are the values needed to successfully build and deploy an app in DSB's infrastructure.
-  Some varibles are slightly different if the build was triggered from a PR. This is to support PR builds and deployments.
-  Where possible values from input 'app-vars' are preffered.
-author: 'Peder Schmedling'
+  Some variables are slightly different if the build was triggered from a PR. This is to support PR builds and deployments.
+  Where possible values from input 'app-vars' are preferred.
+author: "Peder Schmedling"
 inputs:
   app-vars:
-    description: 'Specifications of application to build and/or deploy, created by the create-app-vars workflow.'
+    description: "Specifications of application to build and/or deploy, created by the create-app-vars workflow."
+    required: true
+  github-json:
+    description: "The 'github' context as JSON, passed from the calling workflow with '{{ toJSON(github) }}'"
+    required: true
+  secrets-json:
+    description: "The 'secrets' context as JSON, passed from the calling workflow with '{{ toJSON(secrets) }}'"
+    required: true
+  vars-json:
+    description: "The 'vars' context as JSON, passed from the calling workflow with '{{ toJSON(vars) }}'"
     required: true
   application-source-path:
-    description: 'The path to the appication source code.'
+    description: "The path to the application source code."
     required: false
-    default: './'
+    default: "./"
   application-vendor:
-    description: 'Vendor of application beeing built. Added as label in docker image.'
+    description: "Vendor of application being built. Added as label in docker image."
     required: false
     default: Norwegian Directorate for Civil Protection
   docker-image-registry:
-    description: 'Docker image registry to push built image and tags to.'
+    description: "Docker image registry to push built image and tags to."
     required: false
     default: dsbacr.azurecr.io
   docker-image-repo:
@@ -31,68 +40,122 @@ inputs:
       Note: For images built from PRs this has no effect. A hardcoded value will be used when pruning PR images.
       Also note: This setting will only affects images older than what is set for 'docker-image-prune-keep-num-days'.
     required: false
-    default: '30'
+    default: "30"
   docker-image-prune-keep-num-days:
     description: |
       Minimum number of days that images will be preserved for a given application when performing prune on the application image repo.
       Note: For images built from PRs this has no effect. A hardcoded value will be used when pruning PR images.
       Also note: All images newer than given value will be preserved regardless of what is set for 'docker-image-prune-keep-min-images'.
     required: false
-    default: '180'
+    default: "180"
   acr-username:
     description: 'Username for given "docker-image-registry", user must have push pull rights. Used for docker build and docker push.'
     required: false
-    default: ''
+    default: ""
   acr-password:
     description: 'Password for the user given in "acr-username".'
     required: false
-    default: ''
+    default: ""
   acr-service-principal:
     description: 'Service principal with rights to delete from "docker-image-registry" (ACR). Used for teardown operation of ephemeral PR environments.'
     required: false
-    default: ''
-  maven-repo-pom-id:
-    description: 'Value of the repository/id field in the pom.xml representing repo.dsb.no.'
+    default: ""
+  maven-user-settings-repositories-yml:
+    description: |
+      A YAML list (as string) with information about maven repositories that will be used to create a maven settings.xml prior to invoking maven.
+      The order of the repositories dictates in what order maven will search the repos for artifacts.
     required: false
-    default: dsb-nexus
-  maven-repo-username:
-    description: 'Username to use when downloading dependencies from repo.dsb.no.'
-    required: true
-  maven-repo-token:
-    description: 'Token for downloading dependencies from repo.dsb.no.'
-    required: true
+    default: |
+      repositories:
+        - id: "github-dsb-norge"
+          name: "GitHub: dsb-norge"
+          url: "https://maven.pkg.github.com/dsb-norge/.github"
+          username: "${env.DSB_GH_PKG_USERNAME}"
+          password: "${env.DSB_GH_PKG_PASSWORD}"
+        - id: "dsb-nexus"
+          name: "On-prem: Nexus"
+          url: "https://repo.dsb.no/repository/dsb"
+          username: "${env.DSB_NEXUS_USERNAME}"
+          password: "${env.DSB_NEXUS_PASSWORD}"
+  maven-extra-envs-from-github-yml:
+    description: |
+      A YAML map (as string) with extra environment variables to define in same scope as maven, prior to invoking maven.
+      The value of the environment variables are retrieved from one of the three github contexts: secrets, vars or github.
+
+      Example, create environment variable 'MY_VAR' with value from
+      the variable 'MY_ORG_VARIABLE' (retrieved from the github context 'vars'):
+      ```yml
+      from-variables:
+        MY_VAR: "MY_ORG_VARIABLE"
+      ```
+
+      Github contexts ref. https://docs.github.com/en/actions/learn-github-actions/contexts#inputs-context
+    required: false
+    default: |
+      from-secrets:
+        DSB_NEXUS_PASSWORD: "ORG_MAVEN_REPO_TOKEN"
+      from-variables:
+        DSB_NEXUS_USERNAME: "ORG_MAVEN_REPO_USERNAME"
+      from-github-context:
+        DSB_GH_PKG_USERNAME: "actor"
+        DSB_GH_PKG_PASSWORD: "token"
+  maven-build-project-deploy-to-repositories-yml:
+    description: |
+      A YAML map (as string), when deploying maven artifacts maven will be invoked once for each key-value pair.
+      Each 'key::value' will be passed as 'id::default::url' to the maven deploy mojo as parameter 'altDeploymentRepository':
+        key   -> id     : The id can be used to pick up the correct credentials from settings.xml
+        -     -> default: Hardcoded value for maven2 repo compatibility
+        value -> url    : The location of the repository
+      ref. https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html
+
+      Since github actions do not support github variables in action input default values:
+        A special syntax is supported to allow for substituting in the caller repo into the 'value'.
+        Notice the missing dollar sign preceding the '{{ }}'-expression below.
+        Example:
+          When called from a repo 'foo' owned by the organization 'bar' and the configuration:
+            my-repo-id: "https://maven.pkg.github.com/{{ github.repository }}"
+          the result would be:
+            my-repo-id: "https://maven.pkg.github.com/bar/foo"
+    required: false
+    default: |
+      release-repositories:
+        github-dsb-norge: "https://maven.pkg.github.com/{{ github.repository }}"
+        dsb-nexus: "https://repo.dsb.no/repository/dsb-releases"
+      snapshot-repositories:
+        github-dsb-norge: "https://maven.pkg.github.com/{{ github.repository }}"
+        dsb-nexus: "https://repo.dsb.no/repository/dsb-snapshots"
   sonarqube-token:
-    description: 'Token used for SonarQube app, see https://docs.sonarqube.org/latest/analysis/github-integration/'
+    description: "Token used for SonarQube app, see https://docs.sonarqube.org/latest/analysis/github-integration/"
     required: true
   jasypt-password:
     description: 'Jasypt password. Will be passed to maven build as environment variable named "JASYPT_LOCAL_ENCRYPTOR_PASSWORD"'
     required: false
-    default: ''
+    default: ""
   java-version:
-    description: 'Version of java specified when calling actions/setup-java'
+    description: "Version of java specified when calling actions/setup-java"
     required: false
-    default: '11'
+    default: "11"
   java-distribution:
-    description: 'Distribution of Java specified when calling actions/setup-java'
+    description: "Distribution of Java specified when calling actions/setup-java"
     required: false
     default: temurin
   nodejs-version:
-    description: 'Version of Node.js specified when calling actions/setup-node'
+    description: "Version of Node.js specified when calling actions/setup-node"
     required: false
-    default: '16'
+    default: "16"
   github-repo-token:
-    description: 'Github repo token is required by: 1) Maven Sonar plugin to get PR information; 2) Adding comments from actions to github PRs.'
+    description: "Github repo token is required by: 1) Maven Sonar plugin to get PR information; 2) Adding comments from actions to github PRs."
     required: true
   app-config-repo:
     description: |
       Repo containing application configuration for apps used during deploy to ephemeral environment and static environments.
       This input is required when deploying apps.'
     required: false
-    default: 'dsb-norge/azure-kubernetes-config'
+    default: "dsb-norge/azure-kubernetes-config"
   app-config-repo-token:
-    description: 'Token for performing checkout and commits to the above repo during deploy. This input is required when deploying apps.'
+    description: "Token for performing checkout and commits to the above repo during deploy. This input is required when deploying apps."
     required: false
-    default: ''
+    default: ""
   static-deploy-environments:
     description: |
       Comma separated list of static environments to deploy to.
@@ -104,124 +167,146 @@ inputs:
       Set this to 'false' to allow deploying to static environments from other branches than the default branch.
       The default is to allow only deploys from the default branch.
     required: false
-    default: 'true'
+    default: "true"
   pr-deploy-app-config-branch:
     description: |
       Name of branch in "app-config-repo" potentially containing modified app config used during deploy to ephemeral
       environment. If branch does not exist deploy will fallback to HEAD @ default branch.'
     required: false
-    default: '${{ github.head_ref }}'
+    default: "${{ github.head_ref }}"
   pr-deploy-aks-cluster-name:
-    description: 'Name of AKS instance to use during deploy to ephemeral environment. This input is required when deploying to to ephemeral environments.'
+    description: "Name of AKS instance to use during deploy to ephemeral environment. This input is required when deploying to to ephemeral environments."
     required: false
-    default: 'aks-rg7-ss2-cm-k8s-cluster-dev-1'
+    default: "aks-rg7-ss2-cm-k8s-cluster-dev-1"
   pr-deploy-aks-resource-group:
     description: |
       Name of resource group where the AKS instance to use during deploy to ephemeral environment lives. This input is
       required when deploying to to ephemeral environments.'
     required: false
-    default: 'rg7-ss2-cm-k8s-dev'
+    default: "rg7-ss2-cm-k8s-dev"
   pr-deploy-aks-creds:
     description: |
       Credentials to the AKS instance to use during deploy to ephemeral environment. This input is required when
       deploying to to ephemeral environments.
     required: false
-    default: ''
+    default: ""
   pr-deploy-additional-helm-values:
-    description: 'Additional values.yml overrides passed to Helm. The multiline string is saved to file and and passed to Helm using --vaules option.'
+    description: "Additional values.yml overrides passed to Helm. The multiline string is saved to file and and passed to Helm using --vaules option."
     required: false
-    default: ''
+    default: ""
   pr-deploy-argo-applications-url:
-    description: 'URL to applications overview in ArgoCD. Used when creating comments on PRs during deploy to ephemeral environments.'
+    description: "URL to applications overview in ArgoCD. Used when creating comments on PRs during deploy to ephemeral environments."
     required: false
-    default: 'https://argo.dev.dsbnorge.no/applications'
+    default: "https://argo.dev.dsbnorge.no/applications"
   pr-deploy-comment-prefix:
     description: |
       Used when creating comments on PRs during deploy to ephemeral environments. All comments will be prfixed with this string.
       It is also used when looking for comment(s) to delete prior to creating a new comment. I.e. make sure this is a bit uniqe
       or you will loose comments on our PR. This string will in turn be prefixed with application name.
     required: false
-    default: 'auto-deployed to ephemeral PR environment:'
+    default: "auto-deployed to ephemeral PR environment:"
 outputs:
   json:
-    description: 'All envs as json'
+    description: "All envs as json"
     value: ${{ steps.build-env.outputs.json }}
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     # decide on git ref for app config repo branch
     - id: checkout-config-branch
       shell: bash
+      env:
+        GH_TOKEN: "${{ inputs.app-config-repo-token }}"
       run: |
         # Test if branch ${{ inputs.pr-deploy-app-config-branch }} exists in config repo
 
-        GH_TOKEN='${{ inputs.app-config-repo-token }}'
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        log-info 'Using GitHub token for application config repo from input 'app-config-repo-token' ...'
         GH_TOKEN_SANITIZED=${GH_TOKEN/ }
+        mask-value "${GH_TOKEN_SANITIZED}"
+
+        log-info 'Cloning branch "${{ inputs.pr-deploy-app-config-branch }}" of application repo "${{ inputs.app-config-repo }}" ...'
         TMP_FILE=./not-going-to-use-this
-        git clone \
-          --branch '${{ inputs.pr-deploy-app-config-branch }}' \
-          "https://oauth2:${GH_TOKEN_SANITIZED}@github.com/${{ inputs.app-config-repo }}" \
-          ${TMP_FILE} \
-          && echo "ref=${{ inputs.pr-deploy-app-config-branch }}" >> $GITHUB_OUTPUT \
-          && echo 'create-build-envs: ref "${{ inputs.pr-deploy-app-config-branch }}" exist in "${{ inputs.app-config-repo }}" and will be used for PR deploys.' \
-          || echo "ref=main" >> $GITHUB_OUTPUT \
-          || echo 'create-build-envs: ref "${{ inputs.pr-deploy-app-config-branch }}" does not exist in "${{ inputs.app-config-repo }}", using "main" for PR deploys.'
-        rm -rf ${TMP_FILE}
+        if (
+          git clone \
+            --branch '${{ inputs.pr-deploy-app-config-branch }}' \
+            "https://oauth2:${GH_TOKEN_SANITIZED}@github.com/${{ inputs.app-config-repo }}" \
+            ${TMP_FILE}
+        ); then
+          echo "ref=${{ inputs.pr-deploy-app-config-branch }}" >> $GITHUB_OUTPUT
+          log-info 'Ref "${{ inputs.pr-deploy-app-config-branch }}" exist in "${{ inputs.app-config-repo }}" and will be used for PR deploys.'
+        else
+          echo "ref=main" >> $GITHUB_OUTPUT
+          log-info 'Ref "${{ inputs.pr-deploy-app-config-branch }}" does not exist in "${{ inputs.app-config-repo }}", using "main" for PR deploys.'
+        fi
+        rm -rf ${TMP_FILE} || :
 
     # generate DSB build variables
     - id: build-env
       shell: bash
+      env:
+        ALL_ACTION_INPUTS: "${{ toJSON(inputs) }}"
+        APP_VARS_JSON: "${{ inputs.app-vars }}"
+        GITHUB_JSON: "${{ inputs.github-json }}"
+        SECRETS_JSON: "${{ inputs.secrets-json }}"
+        VARS_JSON: "${{ inputs.vars-json }}"
+        PR_HELM_VALUES_YML: "${{ inputs.inputs.pr-deploy-additional-helm-values }}"
+        MVN_SETTINGS_REPOS_YML: "${{ inputs.maven-user-settings-repositories-yml }}"
+        MVN_EXTRA_GH_ENVS_YML: "${{ inputs.maven-extra-envs-from-github-yml }}"
+        MVN_DEPLOY_REPOS_YML: "${{ inputs.maven-build-project-deploy-to-repositories-yml }}"
       run: |
         # Define variables needed for build and deploy of DSB apps
 
-        # Load and log app vars
-        # Output will be a modified version of given app vars
-        OUTPUT_ENV_JSON=$(cat <<'EOF'
-        ${{ inputs.app-vars }}
-        EOF
-        )
-        echo "::group::create-build-envs: given app vars JSON specification"
-        echo "${OUTPUT_ENV_JSON}"
-        echo "::endgroup::"
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+        set -o allexport; source "${{ github.action_path }}/helpers_build_env.sh"; set +o allexport;
 
-        # Read action inputs as JSON
-        ACTION_INPUTS=$(cat <<'EOF'
-        ${{ toJSON(inputs) }}
-        EOF
-        )
+        # log inputs without secrets
+        log-multiline "action input 'app-vars', the app vars JSON specification" "${APP_VARS_JSON}"
+        log-multiline "action input 'vars-json', the 'vars' context" "${VARS_JSON}"
+        log-multiline "action input 'pr-deploy-additional-helm-values'" "${PR_HELM_VALUES_YML}"
+        log-multiline "action input 'maven-extra-envs-from-github-yml'" "${MVN_EXTRA_GH_ENVS_YML}"
+        log-multiline "action input 'maven-build-project-deploy-to-repositories-yml'" "${MVN_DEPLOY_REPOS_YML}"
 
         # These fields will be set by action inputs and values from app vars will be ignored
         PROTECTED_ENVS=(
           acr-password
+          acr-service-principal
           app-config-repo-token
           github-repo-token
           jasypt-password
-          maven-repo-token
-          sonarqube-token
+          maven-extra-envs-from-github
           pr-deploy-aks-creds
-          acr-service-principal
+          sonarqube-token
         )
 
         # Values for these fields will be handled specifically below
-        #  - app-vars is used as basis for output and should not be added as seprate field.
+        #  - app-vars is used as basis for output and should not be added as separate field.
         #  - helm values requires special format, see further down.
         #  - docker-image-prune-* is hardcoded when running from a PR.
+        #  - *-json is used in this action, contains sensitive information and should not be returned
         #  The rest is generated in this script and should not be added from app vars.
         SPECIAL_ENVS=(
           app-vars
-          pr-deploy-additional-helm-values
-          pr-deploy-k8s-application-name
-          pr-deploy-k8s-namespace
           application-image-id
-          pr-deploy-app-config-branch
           application-source
           application-source-revision
+          caller-repo-calling-branch
+          caller-repo-default-branch
+          caller-repo-is-on-default-branch
           docker-image-prune-keep-min-images
           docker-image-prune-keep-num-days
-          caller-repo-default-branch
-          caller-repo-calling-branch
-          caller-repo-is-on-default-branch
+          github-json
+          maven-build-project-deploy-to-repositories-yml
+          maven-extra-envs-from-github-yml
+          maven-user-settings-repositories-yml
+          pr-deploy-additional-helm-values
+          pr-deploy-app-config-branch
+          pr-deploy-k8s-application-name
+          pr-deploy-k8s-namespace
+          secrets-json
+          vars-json
         )
 
         # These does not contain any secrets and are safe to share
@@ -257,17 +342,15 @@ runs:
           maven-build-project-deploy-snapshot-artifacts
           maven-build-project-deploy-snapshot-deploy-command
           maven-build-project-deploy-snapshot-version-command
-          maven-build-project-github-packages-enabled
+          maven-build-project-deploy-to-repositories-yml
           maven-build-project-goals
           maven-build-project-version-arguments
           maven-build-project-version-command
           maven-build-project-version-goals
-          maven-repo-pom-id
-          maven-repo-username
-          nodejs-build-project-custom-command-pre-npm-ci
-          nodejs-build-project-custom-command-pre-npm-run-lint
-          nodejs-build-project-custom-command-pre-npm-run-build
           nodejs-build-project-custom-command-final
+          nodejs-build-project-custom-command-pre-npm-ci
+          nodejs-build-project-custom-command-pre-npm-run-build
+          nodejs-build-project-custom-command-pre-npm-run-lint
           nodejs-version
           pr-deploy-additional-helm-values
           pr-deploy-aks-cluster-name
@@ -288,47 +371,31 @@ runs:
           static-deploy-from-default-branch-only
         )
 
-        # Helper functions
-        # Add/overwrite fields in OUTPUT_ENV_JSON safely
-        function set-field { OUTPUT_ENV_JSON=$(echo "${OUTPUT_ENV_JSON}" | jq --arg name "$1" --arg value "$2" '.[$name] = $value') ; }
-        # Check if field exists in OUTPUT_ENV_JSON safely
-        function has-field { if [[ "$(echo "${OUTPUT_ENV_JSON}"| jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
-        # Get field value from OUTPUT_ENV_JSON safely
-        function get-val { echo "${OUTPUT_ENV_JSON}" | jq -r --arg name "$1" '.[$name]'; }
-        # Get field value from action inputs safely
-        function get-input-val { echo "${ACTION_INPUTS}" | jq -r --arg name "$1" '.[$name]'; }
-        # True if value is in array PROTECTED_ENVS
-        function is-protected { if [[ " ${PROTECTED_ENVS[*]} " =~ " ${1} " ]]; then true; else false; fi; }
-        # True if value is in array SPECIAL_ENVS
-        function is-special { if [[ " ${SPECIAL_ENVS[*]} " =~ " ${1} " ]]; then true; else false; fi; }
-
         # Loop over all inputs to this action:
         #  - If the field is "special", do nothing
         #  - If field is protected: use value from this action inputs
-        #  - If field does not exist in from app vars: use value from this action inputs
+        #  - If field does not exist in app vars: use value from this action inputs
         # This enables the possibility to override all but protected fields from app vars.
-        INPUT_NAMES=($(echo "${ACTION_INPUTS}" | jq -r '.|keys|.[]'))
+        INPUT_NAMES=($(echo "${ALL_ACTION_INPUTS}" | jq -r '.|keys|.[]'))
         for NAME in ${INPUT_NAMES[*]}; do
           if (is-protected "${NAME}" || ! has-field "${NAME}") && ! is-special "${NAME}"; then
-            # echo "create-build-envs: DEBUG: Using input value for field '${NAME}'"
             set-field "${NAME}" "$(get-input-val "${NAME}")"
           fi
         done
 
-        # Handled specifically as app vars field is on JSON format and
-        # 'pr-deploy-additional-helm-values' is expected to be yaml format (as multiline string)
+        # Handle 'pr-deploy-additional-helm-values' specifically
+        #   app vars field is on JSON format whilst this actions input expects yml
         if has-field "pr-deploy-additional-helm-values"; then
-          echo "create-build-envs: converting app var 'pr-deploy-additional-helm-values' to yaml ..."
-          CONVERTED_VAL=$(echo "$(get-val 'pr-deploy-additional-helm-values')" | yq e -P -)
-          set-field "pr-deploy-additional-helm-values" "${CONVERTED_VAL}"
+          log-info "using 'pr-deploy-additional-helm-values' from app vars."
+          log-info "converting app var 'pr-deploy-additional-helm-values' from JSON to valid yaml ..."
+          PRETTY_VAL=$(echo "$(get-val 'pr-deploy-additional-helm-values')" | yq --input-format json --output-format yml --prettyPrint eval -)
         else
-          echo "create-build-envs: using 'pr-deploy-additional-helm-values' from this action's input"
-          HELM=${{ inputs.pr-deploy-additional-helm-values }}
-          set-field "pr-deploy-additional-helm-values" "${{ inputs.pr-deploy-additional-helm-values }}"
+          log-info "using 'pr-deploy-additional-helm-values' from this action's input"
+          log-info "validating 'pr-deploy-additional-helm-values' as valid yaml ..."
+          PRETTY_VAL=$(echo "${PR_HELM_VALUES_YML}" | yq --input-format yml --output-format yml --prettyPrint eval -)
         fi
-        echo "::group::create-build-envs: resulting value of 'pr-deploy-additional-helm-values'"
-        echo "$(get-val 'pr-deploy-additional-helm-values')"
-        echo "::endgroup::"
+        set-field "pr-deploy-additional-helm-values" "${PRETTY_VAL}"
+        log-multiline "resulting value of 'pr-deploy-additional-helm-values'" "$(get-val 'pr-deploy-additional-helm-values')"
 
         # Differs depending on PR build or not, allow app vars to override
         PR_KUBERNETES_NAMESPACE="$(get-val 'application-name')"
@@ -362,10 +429,112 @@ runs:
 
         # Calling repo branches information
         REPO_DEFAULT_BRANCH=$(curl -s https://api.github.com/repos/${{ github.repository }} -H "Authorization: bearer ${{ github.token }}" | jq -r .default_branch)
-        REPO_CURERNT_BRANCH_IS_DEFAULT=false
+        REPO_CURRENT_BRANCH_IS_DEFAULT=false
         if [ "${{ github.ref_name }}" == "${REPO_DEFAULT_BRANCH}" ]; then
-          REPO_CURERNT_BRANCH_IS_DEFAULT=true
+          REPO_CURRENT_BRANCH_IS_DEFAULT=true
         fi
+
+        # Handled specifically as app vars field is on JSON format and
+        # 'maven-user-settings-repositories-yml' is expected to be yaml format (as multiline string)
+        if has-field "maven-user-settings-repositories-yml"; then
+          log-info "using 'maven-user-settings-repositories-yml' from app vars."
+          REPOS_YML="$(get-val 'maven-user-settings-repositories-yml')"
+        else
+          log-info "using 'maven-user-settings-repositories-yml' from this action's input"
+          REPOS_YML="${MVN_SETTINGS_REPOS_YML}"
+        fi
+        log-info "validating app var 'maven-user-settings-repositories-yml' as yaml ..."
+        PRETTY_VAL=$(echo "${REPOS_YML}" | yq --input-format yml --output-format yml --prettyPrint eval -)
+        set-field "maven-user-settings-repositories-yml" "${PRETTY_VAL}"
+
+        # 'maven-extra-envs-from-github-yml' is expected to be yaml format (as multiline string)
+        # and be converted to a JSON object named 'maven-extra-envs-from-github' compatible with the 'build-maven-project' action.
+        if has-field "maven-extra-envs-from-github-yml"; then
+          log-info "using 'maven-extra-envs-from-github-yml' from app vars."
+          ENVS_YML="$(get-val 'maven-extra-envs-from-github-yml')"
+        else
+          log-info "using 'maven-extra-envs-from-github-yml' from this action's input"
+          ENVS_YML="${MVN_EXTRA_GH_ENVS_YML}"
+        fi
+        log-info "converting app var 'maven-extra-envs-from-github-yml' to json ..."
+        ENVS_JSON=$(echo "${ENVS_YML}" | yq --input-format yml --output-format json --prettyPrint eval -)
+
+        # 'maven-extra-envs-from-github-yml' will be converted to json as # 'maven-extra-envs-from-github'
+        # and populated with values from contexts in github
+
+        ENVS_POPULATED_JSON='{}' # will hold named envs with values
+
+        log-info "populating 'maven-extra-envs-from-github-yml' with values from the 'github' context ..."
+        ENV_NAMES=($(echo "${ENVS_JSON}" | jq -r 'select(."from-github-context" != null) | ."from-github-context" | keys | .[]'))
+        for ENV_NAME in ${ENV_NAMES[*]}; do
+          log-info "  environment variable '${ENV_NAME}'"
+          CONTEXT_FIELD=$(echo "${ENVS_JSON}" | jq -r --arg name "${ENV_NAME}" '."from-github-context" | .[$name]')
+          log-info "   with value from secret '${CONTEXT_FIELD}'"
+          if ! gh-context-has-field "${CONTEXT_FIELD}"; then
+            log-error "A field named '${CONTEXT_FIELD}' does not exist in the current 'github' context!"
+            exit 1
+          fi
+          set-envs-field "${ENV_NAME}" "$(gh-context-get-val ${CONTEXT_FIELD})" # modifies ENVS_POPULATED_JSON
+        done
+
+        log-info "populating 'maven-extra-envs-from-github-yml' from the 'secrets' context ..."
+        ENV_NAMES=($(echo "${ENVS_JSON}" | jq -r 'select(."from-secrets" != null) | ."from-secrets" | keys | .[]'))
+        for ENV_NAME in ${ENV_NAMES[*]}; do
+          log-info "  environment variable '${ENV_NAME}'"
+          CONTEXT_FIELD=$(echo "${ENVS_JSON}" | jq -r --arg name "${ENV_NAME}" '."from-secrets" | .[$name]')
+          log-info "   with value from secret '${CONTEXT_FIELD}'"
+          if ! secret-context-has-field "${CONTEXT_FIELD}"; then
+            log-error "A field named '${CONTEXT_FIELD}' does not exist in the current 'secrets' context!"
+            exit 1
+          fi
+          set-envs-field "${ENV_NAME}" "$(secret-context-get-val ${CONTEXT_FIELD})" # modifies ENVS_POPULATED_JSON
+        done
+
+        log-info "populating 'maven-extra-envs-from-github-yml' from the 'variables' context ..."
+        ENV_NAMES=($(echo "${ENVS_JSON}" | jq -r 'select(."from-variables" != null) | ."from-variables" | keys | .[]'))
+        for ENV_NAME in ${ENV_NAMES[*]}; do
+          log-info "  environment variable '${ENV_NAME}'"
+          CONTEXT_FIELD=$(echo "${ENVS_JSON}" | jq -r --arg name "${ENV_NAME}" '."from-variables" | .[$name]')
+          log-info "   with value from secret '${CONTEXT_FIELD}'"
+          if ! vars-context-has-field "${CONTEXT_FIELD}"; then
+            log-error "A field named '${CONTEXT_FIELD}' does not exist in the current 'variables' context!"
+            exit 1
+          fi
+          set-envs-field "${ENV_NAME}" "$(vars-context-get-val ${CONTEXT_FIELD})" # modifies ENVS_POPULATED_JSON
+        done
+
+        log-info "'maven-extra-envs-from-github-yml' now becomes JSON field named 'maven-extra-envs-from-github' ..."
+        set-field "maven-extra-envs-from-github" "${ENVS_POPULATED_JSON}"
+
+        log-info "removing 'maven-extra-envs-from-github-yml' from output ..."
+        rm-field "maven-extra-envs-from-github-yml"
+
+        # Handled specifically as app vars field is on JSON format and
+        # 'maven-build-project-deploy-to-repositories-yml' is expected to be yaml format (as multiline string)
+        if has-field "maven-build-project-deploy-to-repositories-yml"; then
+          log-info "using 'maven-build-project-deploy-to-repositories-yml' from app vars."
+          DEPLOY_REPOS_YML="$(get-val 'maven-build-project-deploy-to-repositories-yml')"
+        else
+          log-info "using default value for 'maven-build-project-deploy-to-repositories-yml' from this action's input"
+          DEPLOY_REPOS_YML="${MVN_DEPLOY_REPOS_YML}"
+        fi
+
+        log-info "validating app var 'maven-build-project-deploy-to-repositories-yml' as yaml ..."
+        PRETTY_VAL=$(echo "${DEPLOY_REPOS_YML}" | yq --input-format yml --output-format yml --prettyPrint eval -)
+
+        log-info "injecting caller repo into 'maven-build-project-deploy-to-repositories-yml' ..."
+        # loops over repo maps and substitutes in the actual caller repo
+        INJECTED_VAL=$(
+          echo "${PRETTY_VAL}" |
+            yq --input-format yml --output-format yml eval '
+              .[] |=
+              .[] |=
+              sub("{{ github.repository }}", "${{ github.repository }}")
+            '
+        )
+
+        set-field "maven-build-project-deploy-to-repositories-yml" "${INJECTED_VAL}"
+        log-multiline "resulting value of 'maven-build-project-deploy-to-repositories-yml'" "$(get-val 'maven-build-project-deploy-to-repositories-yml')"
 
         # Generated fields, not possible to override from app vars
         IMAGE_ID="$(get-val 'docker-image-registry')/$(get-val 'docker-image-repo')/$(get-val 'application-image-name')"
@@ -375,30 +544,28 @@ runs:
         set-field "application-source-revision"       '${{ github.sha }}'
         set-field "caller-repo-default-branch"        "${REPO_DEFAULT_BRANCH}"
         set-field "caller-repo-calling-branch"        "${{ github.ref_name }}"
-        set-field "caller-repo-is-on-default-branch"  "${REPO_CURERNT_BRANCH_IS_DEFAULT}"
+        set-field "caller-repo-is-on-default-branch"  "${REPO_CURRENT_BRANCH_IS_DEFAULT}"
 
-        echo "create-build-envs: Number of envs: $(echo ${OUTPUT_ENV_JSON} | jq 'length')"
+        log-info "Number of envs: $(echo ${APP_VARS_JSON} | jq 'length')"
 
         # Separate output JSON not contain any secrets. Considered safe
         # to share with other jobs and upload to github in a build artifact
         ENVS_WITHOUT_SECRETS_STRING=${ENVS_WITHOUT_SECRETS[*]}
         JQ_SELECT_FIELDS_FORMAT="{\"${ENVS_WITHOUT_SECRETS_STRING// /\",\"}\"}"
-        OUTPUT_ENV_JSON_NOT_SECRET=$(echo "${OUTPUT_ENV_JSON}" | jq "${JQ_SELECT_FIELDS_FORMAT}")
+        APP_VARS_JSON_NOT_SECRET=$(echo "${APP_VARS_JSON}" | jq "${JQ_SELECT_FIELDS_FORMAT}" | jq 'del(..|nulls)')
 
         OUT_DIR=./_create-build-envs
         OUT_JSON_FILE="${OUT_DIR}/$(get-val 'application-name').json"
-        echo "create-build-envs: $(echo "${OUTPUT_ENV_JSON_NOT_SECRET}" | jq 'length') non-secret envs will be saved to file: ${OUT_JSON_FILE}"
+        log-info "$(echo "${APP_VARS_JSON_NOT_SECRET}" | jq 'length') non-secret envs will be saved to file: ${OUT_JSON_FILE}"
         mkdir -p ${OUT_DIR}
-        echo "::group::create-build-envs: non-secret envs JSON"
-        echo "${OUTPUT_ENV_JSON_NOT_SECRET}" | tee "${OUT_JSON_FILE}"
-        echo "::endgroup::"
+        log-multiline "non-secret envs JSON" "$(echo "${APP_VARS_JSON_NOT_SECRET}" | tee "${OUT_JSON_FILE}")"
 
         echo "json-without-secrets-path=${OUT_JSON_FILE}" >> $GITHUB_OUTPUT
 
         echo "build-envs-artifact-name=build-envs-$(get-val 'application-version')"  >> $GITHUB_OUTPUT
 
         echo 'json<<"${{ github.run_id }}"' >> $GITHUB_OUTPUT
-        echo "${OUTPUT_ENV_JSON}" >> $GITHUB_OUTPUT
+        echo "${APP_VARS_JSON}" >> $GITHUB_OUTPUT
         echo '"${{ github.run_id }}"' >> $GITHUB_OUTPUT
 
     - uses: actions/upload-artifact@v3

--- a/ci-cd/create-build-envs/helpers.sh
+++ b/ci-cd/create-build-envs/helpers.sh
@@ -1,0 +1,21 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name='create-build-envs'
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/ci-cd/create-build-envs/helpers_build_env.sh
+++ b/ci-cd/create-build-envs/helpers_build_env.sh
@@ -1,0 +1,52 @@
+#!/bin/env bash
+
+# Helper functions for working with JSON to output
+# ================================================
+
+# Add/overwrite fields in APP_VARS_JSON safely
+function set-field { APP_VARS_JSON=$(echo "${APP_VARS_JSON}" | jq --arg name "$1" --arg value "$2" '.[$name] = $value'); }
+function set-field-from-json { APP_VARS_JSON=$(echo "${APP_VARS_JSON}" | jq --arg name "$1" --argjson json_value "$2" '.[$name] = $json_value'); }
+
+# Remove fields from APP_VARS_JSON safely
+function rm-field { APP_VARS_JSON=$(echo "${APP_VARS_JSON}" | jq --arg key_name "$1" 'del(.[$key_name])'); }
+
+# Check if field exists in APP_VARS_JSON safely
+function has-field { if [[ "$(echo "${APP_VARS_JSON}" | jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
+
+# Get field value from APP_VARS_JSON safely
+function get-val { echo "${APP_VARS_JSON}" | jq -r --arg name "$1" '.[$name]'; }
+
+
+# Helper functions for working with the action input
+# ==================================================
+
+# Get field value from action inputs safely
+function get-input-val { echo "${ALL_ACTION_INPUTS}" | jq -r --arg name "$1" '.[$name]'; }
+
+# True if value is in array PROTECTED_ENVS
+function is-protected { if [[ " ${PROTECTED_ENVS[*]} " =~ " ${1} " ]]; then true; else false; fi; }
+
+# True if value is in array SPECIAL_ENVS
+function is-special { if [[ " ${SPECIAL_ENVS[*]} " =~ " ${1} " ]]; then true; else false; fi; }
+
+
+# Helper functions for working with contexts JSONs
+# ================================================
+
+function gh-context-has-field { if [[ "$(echo "${GITHUB_JSON}" | jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
+function gh-context-get-val { echo "${GITHUB_JSON}" | jq -r --arg name "$1" '.[$name]'; }
+
+function secret-context-has-field { if [[ "$(echo "${SECRETS_JSON}" | jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
+function secret-context-get-val { echo "${SECRETS_JSON}" | jq -r --arg name "$1" '.[$name]'; }
+
+function vars-context-has-field { if [[ "$(echo "${VARS_JSON}" | jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
+function vars-context-get-val { echo "${VARS_JSON}" | jq -r --arg name "$1" '.[$name]'; }
+
+
+# Helper functions for JSON with named envs and their values
+# ==========================================================
+
+function set-envs-field { ENVS_POPULATED_JSON=$(echo "${ENVS_POPULATED_JSON}" | jq --arg name "$1" --arg value "$2" '.[$name] = $value') ; }
+
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/ci-cd/create-build-envs/test_action_source.sh
+++ b/ci-cd/create-build-envs/test_action_source.sh
@@ -1,0 +1,31 @@
+#!/bin/env bash
+#
+# A way of actually running the bash code from this github action locally during development
+#
+set -uo pipefail
+
+this_script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# the github actions def to test
+action_def_file="${this_script_dir}/action.yml"
+
+# load test runner code
+source "${this_script_dir}/test_action_source_helpers.sh"
+
+if [ "${1-}" == "clean" ]; then
+  del_files=$(find "${this_script_dir}" -name '_*' -print | sort)
+  if [ ! -z "${del_files}" ]; then
+    echo "deleting these:"
+    echo "${del_files}" | xargs realpath --relative-to=$(pwd)
+    echo "${del_files}" | xargs rm
+  else
+    echo "nothing to delete"
+  fi
+  exit 0
+fi
+
+# run tests
+should_pass_test 'test_input_minimal' "${action_def_file}" "${this_script_dir}"
+should_pass_test 'test_input_happy_day' "${action_def_file}" "${this_script_dir}"
+should_pass_test 'test_input_helm_values_from_input' "${action_def_file}" "${this_script_dir}"
+should_fail_test 'test_input_fail_yml_format' "${action_def_file}" "${this_script_dir}"

--- a/ci-cd/create-build-envs/test_action_source_helpers.sh
+++ b/ci-cd/create-build-envs/test_action_source_helpers.sh
@@ -1,0 +1,246 @@
+#!/bin/env bash
+#
+# See test_action_source.sh
+#
+
+print_divider() {
+  local message="${1-}"
+  if [[ -n "${message}" ]]; then
+    echo ""
+    echo ""
+    echo "${message}"
+  fi
+  echo "$(printf '=%.0s' {1..120})"
+}
+
+trap_exit_positive_test() {
+  # echo "in trap_exit_positive_test, *: $*"
+  [ ! "$1" == "0" ] &&
+    echo -e "\e[31mX\e[0m test fail for '${test_file}'" >$(tty) ||
+    echo -e "\e[32m✓\e[0m test pass for '${test_file}'" >$(tty)
+}
+
+trap_exit_negative_test() {
+  # echo "in trap_exit_negative_test, *: $*"
+  [ "$1" == "0" ] &&
+    echo -e "\e[31mX\e[0m test fail for '${test_file}'" >$(tty) ||
+    echo -e "\e[32m✓\e[0m test pass for '${test_file}'" >$(tty)
+}
+
+should_pass_test() {
+  local script_dir test_file action_def_file
+  test_file="${1}"
+  action_def_file="${2}"
+  script_dir="${3}"
+
+  (
+    set -euo pipefail
+    trap 'trap_exit_positive_test $?' EXIT
+    trap 'trap_exit_positive_test $?' ERR
+    test_action "${action_def_file}" "${script_dir}/${test_file}" >"${script_dir}/__${test_file}.stdout" 2>"${script_dir}/__${test_file}.stderr"
+    # DEBUG
+    # test_action "${action_def_file}" "${script_dir}/${test_file}"
+    set -uo pipefail
+  )
+  # echo "after should pass"
+}
+
+should_fail_test() {
+  local script_dir test_file action_def_file
+  test_file="${1}"
+  action_def_file="${2}"
+  script_dir="${3}"
+
+  (
+    set -euo pipefail
+    trap 'trap_exit_negative_test $?' EXIT
+    trap 'trap_exit_negative_test $?' ERR
+    test_action "${action_def_file}" "${script_dir}/${test_file}" >"${script_dir}/__${test_file}.stdout" 2>"${script_dir}/__${test_file}.stderr"
+    # DEBUG
+    # test_action "${action_def_file}" "${script_dir}/${test_file}"
+    set -uo pipefail
+  )
+  # echo "after should fail"
+}
+
+test_action() {
+  local action_file input_file_prefix this_script_dir
+
+  action_file="${1}"
+  input_file_prefix="${2}"
+  this_script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+  # read github actions def with yq
+  readarray action_steps < <(yq e -o=j -I=0 --expression='.runs.steps[]' "${action_file}")
+  action_inputs=$(yq e -o=csv -I=0 --expression='.inputs | keys' "${action_file}")
+
+  # count
+  i=1
+
+  # loop all steps in action
+  for step in "${action_steps[@]}"; do
+    step_id=$(echo "$step" | yq e '.id' -)
+    step_src=$(echo "$step" | yq e '.run' -)
+
+    # NOTE: we only test one step for now
+    if [ ! "${step_id}" == "build-env" ]; then
+      continue
+    fi
+
+    print_divider "step id: $i $step_id"
+
+    # the source code for the step will be written to this file
+    step_src_file="${this_script_dir}/_${i}_${step_id}.sh"
+
+    # add some init code
+    cat <<EOF >"${step_src_file}"
+#!/bin/env bash
+set -euo pipefail
+__dirname="${this_script_dir}"
+GITHUB_OUTPUT="${this_script_dir}/_${step_id}.sh.out"
+echo "" > \$GITHUB_OUTPUT
+
+EOF
+
+    # make executable
+    chmod +x "${step_src_file}"
+
+    # parse an query input json
+    input_file="${input_file_prefix}.json"
+    echo "input_file: ${input_file}"
+    json_input=$(cat $input_file)
+    function input-json-has-field { if [[ "$(echo "${json_input}" | jq --arg name "$1" 'has($name)')" == 'true' ]]; then true; else false; fi; }
+    function input-json-get-val { echo "${json_input}" | jq -r --arg name "$1" '.[$name]'; }
+
+    # the whole all action input
+    all_json_input_escaped=$(printf '%s\n' "${json_input}" | sed 's,[\/&],\\&,g;s/$/\\/')
+    all_json_input_escaped=${all_json_input_escaped%?}
+
+    # convert step 'env:' fields to bash variables
+    # loop all 'env:' fields
+    step_env_names=$(echo "$step" | yq -o=csv -I=0 --expression='.env | keys' -)
+    # echo "$step_env_names"
+    for step_env_name in ${step_env_names//,/ }; do
+      # echo "$step_env_name"
+      step_env_val="$(echo "$step" | yq -o=csv -I=0 --expression=".env.$step_env_name" -)"
+      # echo "$step_env_val"
+
+      # loop action inputs and replace in env value
+      for action_input in ${action_inputs//,/ }; do
+        # echo "action_input: ${action_input}"
+
+        # check input json first, then action input default values
+        if input-json-has-field "${action_input}"; then
+          input_value=$(input-json-get-val "${action_input}")
+        else
+          input_value=$(yq e -o=csv -I=0 --expression=".inputs | .${action_input} | .default " "${action_file}")
+        fi
+
+        # for inputs where a value was found, replace in env value
+        if [ ! "null" == "${input_value}" ]; then
+          json_input_escaped=$(printf '%s\n' "${input_value}" | sed 's,[\/&],\\&,g;s/$/\\/')
+          json_input_escaped=${json_input_escaped%?}
+          step_env_val="$(echo "$step_env_val" | sed "s/\${{ inputs\.${action_input} }}/$json_input_escaped/g")"
+        fi
+      done
+
+      # replace any occurance of reading the whole action input
+      step_env_val="$(echo "$step_env_val" | sed "s/\${{ toJSON(inputs) }}/$all_json_input_escaped/g")"
+
+      # insert env name and value as bash variable in script file
+      # echo "$step_env_val"
+      cat <<OEOF >>"${step_src_file}"
+${step_env_name}=\$(cat <<'IEOF'
+${step_env_val}
+IEOF
+)
+
+OEOF
+    done
+
+    # write source from action step
+    {
+      echo "# ==================================================="
+      echo "# START CODE FROM ACTION STEP DEF"
+      echo "# ==================================================="
+      echo ""
+      echo "${step_src}"
+    } >>"${step_src_file}"
+
+    # replace any occurance of reading the whole action input
+    sed -i "s/\${{ toJSON(inputs) }}/$all_json_input_escaped/g" "${step_src_file}"
+
+    for action_input in ${action_inputs//,/ }; do
+      # echo "action_input: ${action_input}"
+
+      if input-json-has-field "${action_input}"; then
+        input_value=$(input-json-get-val "${action_input}")
+      else
+        input_value=$(yq e -o=csv -I=0 --expression=".inputs | .${action_input} | .default " "${action_file}")
+      fi
+
+      if [ "null" == "${input_value}" ]; then
+        echo "Found no value for input '${action_input}'"
+      else
+        # echo "input_value: ${input_value}"
+        json_input_escaped=$(printf '%s\n' "${input_value}" | sed 's,[\/&],\\&,g;s/$/\\/')
+        json_input_escaped=${json_input_escaped%?}
+        # echo "json_input_escaped: ${json_input_escaped}"
+        sed -i "s/\${{ inputs\.${action_input} }}/$json_input_escaped/g" "${step_src_file}"
+      fi
+    done
+
+    # insert input json from steps
+    for _step in "${action_steps[@]}"; do
+      _step_id=$(echo "$_step" | yq e '.id' -)
+
+      # if output file exists
+      step_output_file="${this_script_dir}/_${_step_id}.sh.out"
+      if [ -f "${step_output_file}" ]; then
+        # read output and escape
+        json=$(cat "${step_output_file}")
+        json_escaped=$(printf '%s\n' "${json}" | sed 's,[\/&],\\&,g;s/$/\\/')
+        json_escaped=${json_escaped%?}
+
+        # replace github actions variable with json blob
+        sed -i "s/\${{ steps\.${_step_id}\.outputs\.app-vars }}/$json_escaped/g" "${step_src_file}"
+      fi
+    done
+
+    # fix actions output in step source
+    sed -i "s/echo 'json<</# echo 'app-vars<</g" "${step_src_file}"
+    sed -i "s/echo '\"\${{ github\.run_id/# echo '\"\${{ github\.run_id/g" "${step_src_file}"
+    sed -i "s/echo \"json-without-secrets-path=/# echo \"json-without-secrets-path=/g" "${step_src_file}"
+    sed -i "s/echo \"build-envs-artifact-name=/# echo \"build-envs-artifact-name=/g" "${step_src_file}"
+
+    # replace github action vars
+    sed -i "s/\${{ github\.event\.number }}/9999/g" "${step_src_file}"
+    sed -i "s/\${{ github\.ref_name }}/the-calling-branch/g" "${step_src_file}"
+    sed -i "s/\${{ github\.repository }}/calling-owner\/calling-repo/g" "${step_src_file}"
+    sed -i "s/\${{ github\.action_path }}/\${__dirname}/g" "${step_src_file}"
+
+    # prevent curling to github
+    sed -i "s/REPO_DEFAULT_BRANCH=/REPO_DEFAULT_BRANCH='main' # REPO_DEFAULT_BRANCH=/g" "${step_src_file}"
+
+    # control path of output file
+    out_json_file=$(echo "${this_script_dir}/_${step_id}.OUT_JSON_FILE.out" | sed 's,[\/&],\\&,g;s/$/\\/')
+    sed -i "s/OUT_JSON_FILE=/OUT_JSON_FILE='${out_json_file}' # OUT_JSON_FILE=/g" "${step_src_file}"
+
+    # remove some debug
+    sed -i "s/echo \"\${DEBUG_VARS_JSON/# echo \"\${DEBUG_VARS_JSON/g" "${step_src_file}"
+
+    # debug
+    # [ $i == 7 ] && break
+
+    # execute
+    env -i HOME="$HOME" bash -l -c "${step_src_file}"
+    [ "$?" == "0" ] &&
+      echo "SUCCESS: ${step_src_file}" ||
+      echo "FAILURE: ${step_src_file}"
+
+    # debug
+    # [ $i == 7 ] && break
+
+    ((i++))
+  done
+}

--- a/ci-cd/create-build-envs/test_input_fail_yml_format.json
+++ b/ci-cd/create-build-envs/test_input_fail_yml_format.json
@@ -1,0 +1,23 @@
+{
+  "_COMMENT": "Used for testing this actions code, see test_action_source.sh",
+  "github-repo-token": "***",
+  "sonarqube-token": "***",
+  "app-vars": {
+    "application-description": "An app of DSB",
+    "application-name": "app-name",
+    "application-type": "spring-boot",
+    "pr-deploy-additional-helm-values": "{\"field1:\"value1;\"field2\":\"value2\"}"
+  },
+  "secrets-json": {
+    "ORG_MAVEN_REPO_TOKEN": "the token to a maven repo",
+    "other secret": "1\n2"
+  },
+  "github-json": {
+    "actor": "Liam Neeson",
+    "token": "super secret"
+  },
+  "vars-json": {
+    "ORG_MAVEN_REPO_USERNAME": "the username to a maven repo",
+    "OTHER_VAR": "1\n2"
+  }
+}

--- a/ci-cd/create-build-envs/test_input_happy_day.json
+++ b/ci-cd/create-build-envs/test_input_happy_day.json
@@ -1,0 +1,46 @@
+{
+  "_COMMENT": "Used for testing this actions code, see test_action_source.sh",
+  "acr-password": "***",
+  "acr-service-principal": "***",
+  "acr-username": "name of acr user",
+  "app-config-repo-token": "***",
+  "github-repo-token": "***",
+  "jasypt-password": "***",
+  "pr-deploy-aks-creds": "***",
+  "sonarqube-token": "***",
+  "app-vars": {
+    "application-build-timestamp": "2023-05-31T07:00:14.566Z",
+    "application-description": "An app of DSB",
+    "application-image-name": "app-name",
+    "application-name": "app-name",
+    "application-source-path": "../app-path/backend",
+    "application-type": "spring-boot",
+    "application-version": "2023.05.31.32414",
+    "java-version": "17",
+    "maven-build-project-deploy-release-artifacts": true,
+    "maven-build-project-deploy-snapshot-artifacts": true,
+    "pr-deploy-additional-helm-values": {
+      "parameters": {
+        "dsb-spring-boot.database_container.enabled": true,
+        "dsb-spring-boot.config.spring.datasource.url": "jdbc:sqlserver://\\$\\{DATABASE_CONTAINER_HOST_AND_PORT};database=\\$\\{DATABASE_CONTAINER_DATABASE};encrypt=false",
+        "dsb-spring-boot.config.spring.datasource.username": "\\$\\{DATABASE_CONTAINER_USER}",
+        "dsb-spring-boot.config.spring.datasource.password": "\\$\\{DATABASE_CONTAINER_PASSWORD}",
+        "dsb-spring-boot.config.spring.r2dbc.url": "r2dbc:pool:sqlserver://\\$\\{DATABASE_CONTAINER_HOST_AND_PORT}/\\$\\{DATABASE_CONTAINER_DATABASE}",
+        "dsb-spring-boot.config.spring.r2dbc.username": "\\$\\{DATABASE_CONTAINER_USER}",
+        "dsb-spring-boot.config.spring.r2dbc.password": "\\$\\{DATABASE_CONTAINER_PASSWORD}"
+      }
+    }
+  },
+  "secrets-json": {
+    "ORG_MAVEN_REPO_TOKEN": "the token to a maven repo",
+    "other secret": "1\n2"
+  },
+  "github-json": {
+    "actor": "Liam Neeson",
+    "token": "super secret"
+  },
+  "vars-json": {
+    "ORG_MAVEN_REPO_USERNAME": "the username to a maven repo",
+    "OTHER_VAR": "1\n2"
+  }
+}

--- a/ci-cd/create-build-envs/test_input_helm_values_from_input.json
+++ b/ci-cd/create-build-envs/test_input_helm_values_from_input.json
@@ -1,0 +1,29 @@
+{
+  "_COMMENT": "Used for testing this actions code, see test_action_source.sh",
+  "github-repo-token": "***",
+  "sonarqube-token": "***",
+  "pr-deploy-additional-helm-values": {
+    "parameters": {
+      "dsb-spring-boot.ingress_host": "pr-${{ github.event.number }}-testapp.dev.tld.dad",
+      "dsb-spring-boot.azureKeyVault.vaults.commonKeyVaultForApps.secrets.0.nameInKv": "test-application-serviceaccount-client-secret-pr",
+      "dsb-spring-boot.azureKeyVault.vaults.commonKeyVaultForApps.secrets.0.mountAsEnv": "spring.security.oauth2.client.registration.service-account-test-application.client-secret"
+    }
+  },
+  "app-vars": {
+    "application-description": "An app of DSB",
+    "application-name": "app-name",
+    "application-type": "spring-boot"
+  },
+  "secrets-json": {
+    "ORG_MAVEN_REPO_TOKEN": "the token to a maven repo",
+    "other secret": "1\n2"
+  },
+  "github-json": {
+    "actor": "Liam Neeson",
+    "token": "super secret"
+  },
+  "vars-json": {
+    "ORG_MAVEN_REPO_USERNAME": "the username to a maven repo",
+    "OTHER_VAR": "1\n2"
+  }
+}

--- a/ci-cd/create-build-envs/test_input_minimal.json
+++ b/ci-cd/create-build-envs/test_input_minimal.json
@@ -1,0 +1,16 @@
+{
+  "_COMMENT": "Used for testing this actions code, see test_action_source.sh",
+  "github-repo-token": "***",
+  "sonarqube-token": "***",
+  "maven-user-settings-repositories-yml": "{}",
+  "maven-extra-envs-from-github-yml": "{}",
+  "maven-build-project-deploy-to-repositories-yml": "{}",
+  "app-vars": {
+    "application-description": "An app of DSB",
+    "application-name": "app-name",
+    "application-type": "spring-boot"
+  },
+  "secrets-json": {},
+  "github-json": {},
+  "vars-json": {}
+}

--- a/ci-cd/deploy-multiple-to-static-is-allowed/action.yml
+++ b/ci-cd/deploy-multiple-to-static-is-allowed/action.yml
@@ -35,13 +35,10 @@ runs:
     # check what branch we are deploying from
     - id: evaluate
       shell: bash
+      env:
+        JSON_ARRAY: "${{ inputs.dsb-build-envs-array }}"
       run: |
         # Verify deploy is allowed from calling branch
-
-        JSON_ARRAY=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs-array }}
-        EOF
-        )
 
         # Helper functions
         function _jq { echo "${OBJ}" | base64 --decode | jq -r "${*}" ; }

--- a/ci-cd/deploy-multiple-to-static/action.yml
+++ b/ci-cd/deploy-multiple-to-static/action.yml
@@ -33,13 +33,10 @@ runs:
 
     # checkout config repo(s)
     - shell: bash
+      env:
+        JSON_ARRAY: "${{ inputs.dsb-build-envs-array }}"
       run: |
         # Checkout config repo(s)
-
-        JSON_ARRAY=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs-array }}
-        EOF
-        )
 
         GH_TOKEN='${{ inputs.app-config-repo-token }}'
         GH_TOKEN_SANITIZED=${GH_TOKEN/ }
@@ -53,13 +50,10 @@ runs:
 
     # check if expected directory structure and application config exists
     - shell: bash
+      env:
+        JSON_ARRAY: "${{ inputs.dsb-build-envs-array }}"
       run: |
         # Look for files and directories
-
-        JSON_ARRAY=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs-array }}
-        EOF
-        )
 
         # Helper functions
         function _jq { echo "${OBJ}" | base64 --decode | jq -r "${*}" ; }
@@ -98,13 +92,10 @@ runs:
 
     # update application version in given environments, commit and push
     - shell: bash
+      env:
+        JSON_ARRAY: "${{ inputs.dsb-build-envs-array }}"
       run: |
         # Bump versions in git repo
-
-        JSON_ARRAY=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs-array }}
-        EOF
-        )
 
         # Helper functions
         function _jq { echo "${OBJ}" | base64 --decode | jq -r "${*}" ; }

--- a/ci-cd/require-build-envs/action.yml
+++ b/ci-cd/require-build-envs/action.yml
@@ -30,13 +30,11 @@ runs:
   using: 'composite'
   steps:
     - shell: bash
+      env:
+        JSON_CONFIG: "${{ inputs.dsb-build-envs }}"
+        REQUIRED_KEYS: "${{ inputs.require }}"
       run: |
         # Test build envs
-
-        JSON_CONFIG=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs }}
-        EOF
-        )
 
         # Exit early if no input given
         if [ -z "${JSON_CONFIG}" ]; then
@@ -44,13 +42,13 @@ runs:
           exit 0
         fi
 
-        REQUIRED_KEYS=($(cat <<'EOF'
-        ${{ inputs.require }}
+        REQUIRED_KEYS_ARR=($(cat <<EOF
+        ${REQUIRED_KEYS}
         EOF
         ))
 
         EXIT_CODE=0
-        for KEY in "${REQUIRED_KEYS[@]}"; do
+        for KEY in "${REQUIRED_KEYS_ARR[@]}"; do
           if [ ! "$( jq 'has("'${KEY}'")' <<< ${JSON_CONFIG} )" == "true" ]; then
             echo "ERROR: require-build-envs: Build env '${KEY}' is required but was not found in 'dsb-build-envs' JSON."
             EXIT_CODE=1
@@ -63,13 +61,11 @@ runs:
         exit ${EXIT_CODE}
 
     - shell: bash
+      env:
+        JSON_CONFIG: "${{ inputs.dsb-build-envs-array }}"
+        REQUIRED_KEYS: "${{ inputs.require }}"
       run: |
         # Test build envs array
-
-        JSON_CONFIG=$(cat <<'EOF'
-        ${{ inputs.dsb-build-envs-array }}
-        EOF
-        )
 
         # Exit early if no input given
         if [ -z "${JSON_CONFIG}" ]; then
@@ -77,8 +73,8 @@ runs:
           exit 0
         fi
 
-        REQUIRED_KEYS=($(cat <<'EOF'
-        ${{ inputs.require }}
+        REQUIRED_KEYS_ARR=($(cat <<EOF
+        ${REQUIRED_KEYS}
         EOF
         ))
 
@@ -90,7 +86,7 @@ runs:
         EXIT_CODE=0
         for OBJ in $(echo "${JSON_CONFIG}" | jq -r '.[] | @base64'); do
           JSON_OBJ="$(_jq '.')"
-          for KEY in "${REQUIRED_KEYS[@]}"; do
+          for KEY in "${REQUIRED_KEYS_ARR[@]}"; do
           if ! has-field "${KEY}"; then
             echo "ERROR: require-build-envs: Build env '${KEY}' is required but was not found for the app '$( get-val 'application-name')' in 'dsb-build-envs-array' JSON."
             EXIT_CODE=1

--- a/run-maven-command/action.yml
+++ b/run-maven-command/action.yml
@@ -35,14 +35,15 @@ runs:
           application-source-path
           java-distribution
           java-version
-          maven-repo-pom-id
-          maven-repo-token
-          maven-repo-username
+          maven-extra-envs-from-github
+          maven-user-settings-repositories-yml
+
     # Determine maven command
     - id: mvn-cmd
       shell: bash
       run: |
         # Locate pom.xml
+
         POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}"
         [ ! -f "${POM_FILE}" ] && POM_FILE="${{ fromJSON(inputs.dsb-build-envs).application-source-path }}/pom.xml"
         [ ! -f "${POM_FILE}" ] && \
@@ -54,24 +55,32 @@ runs:
         echo "run-maven-command: Maven command: '${MVN_CMD}'"
         echo "mvn-cmd=${MVN_CMD}" >> $GITHUB_OUTPUT
 
-    # Set up JDK
+    # configure maven settings
+    - uses: dsb-norge/github-actions/ci-cd/configure-maven-settings@v2
+      with:
+        user-settings-repositories-yml: ${{ fromJSON(inputs.dsb-build-envs).maven-user-settings-repositories-yml }}
+
+    # set up JDK
     - uses: actions/setup-java@v3
       with:
         distribution: ${{ fromJSON(inputs.dsb-build-envs).java-distribution }}
         java-version: ${{ fromJSON(inputs.dsb-build-envs).java-version }}
-        server-id: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-pom-id }} # Value of the repository/id field of the pom.xml
-        # Jenkins user in repo.dsb.no. Pwd for login to repo.dsb.no found in keepass
-        server-username: DSB_MAVEN_REPO_USER_NAME
-        server-password: DSB_MAVEN_REPO_TOKEN
-        overwrite-settings: true
+        overwrite-settings: false # do not overwrite settings.xml from the configure-maven-settings action
 
     # Invoke maven
     - shell: bash
-      run: |
-        echo "::group::run-maven-command: Invoke maven with goals"
-        echo "run-maven-project: command string: '${{ steps.mvn-cmd.outputs.mvn-cmd }}'"
-        ${{ steps.mvn-cmd.outputs.mvn-cmd }}
-        echo "::endgroup::"
       env:
-        DSB_MAVEN_REPO_TOKEN: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-token }}
-        DSB_MAVEN_REPO_USER_NAME: ${{ fromJSON(inputs.dsb-build-envs).maven-repo-username }}
+        EXTRA_ENVS_FROM_GH: "${{ fromJSON(inputs.dsb-build-envs).maven-extra-envs-from-github }}"
+      run: |
+        # Invoke maven
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        export-extra-envs "from github" "${EXTRA_ENVS_FROM_GH}"
+
+        start-group "Invoke maven with goals"
+        log-info "command string: '${{ steps.mvn-cmd.outputs.mvn-cmd }}'"
+        ${{ steps.mvn-cmd.outputs.mvn-cmd }}
+        end-group
+
+        unset-extra-envs "from github" "${EXTRA_ENVS_FROM_GH}"

--- a/run-maven-command/helpers.sh
+++ b/run-maven-command/helpers.sh
@@ -1,0 +1,60 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name='run-maven-command'
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+
+
+# Helper functions for working with dsb build envs JSONs
+# ======================================================
+
+function export-extra-envs {
+  _extra-envs 'export' "$@"
+}
+function unset-extra-envs {
+  _extra-envs 'unset' "$@"
+}
+function _extra-envs {
+  local op="${1}"
+  local envs_name="${2}"
+  local envs_json="${3}"
+  local env_names env_name env_value
+
+  if [ "${op}" == "export" ]; then
+    if [ -z "${envs_json}" ] ; then
+      log-info "No '${envs_name}' extra environment variables to export."
+    else
+      start-group "'${envs_name}' extra environment variables exported"
+      env_names=$(echo ${envs_json} | jq -r '[keys[]] | join(" ")')
+      for env_name in ${env_names}; do
+          env_value=$(echo ${envs_json} | jq -r ".${env_name}")
+          echo " - '${env_name}' with value length ${#env_value}"
+          export "${env_name}"="${env_value}"
+      done
+      end-group
+    fi
+  fi
+  if [ "${op}" == "unset" ] && [ ! -z "${envs_json}" ]; then
+      log-info "Removing '${envs_name}' extra environment variables ..."
+      for env_name in ${env_names}; do
+          unset "${env_name}"
+      done
+  fi
+}
+
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."


### PR DESCRIPTION
# Notable changes: maven settings and deploy repos
- new parameter `maven-extra-envs-from-github-yml` makes it possible to export environment variables available to maven with values from the contexts `vars`, `secrets` and `github` in github
- major (non-breaking) changes related to maven settings.xml:
  - no long use `actions/setup-java` to manage maven settings.xml
  - write settings.xml with our own `configure-maven-settings`
    - contents of settings.xml is now configurable through the parameter `maven-user-settings-repositories-yml`
    - it's possible to reference secrets/vars from github in `maven-user-settings-repositories-yml` with the combination of maven's interpolation syntax `${env.MY_ENV}` and new parameter `maven-extra-envs-from-github-yml`. See default values in create-build-envs for example.
- major (non-breaking) changes related to deploy of artifacts with maven:
  - deploy og snapshots/releases is no longer hardcoded to one single maven repo
  - new parameter `maven-build-project-deploy-to-repositories-yml` makes repositories individually configurable for snapshots/releases. Note that credentials for these repos must be configured using the parameter `maven-user-settings-repositories-yml`
- other changes:
  - parameters no longer in use:
    - `maven-repo-pom-id`
    - `maven-repo-username`
    - `maven-repo-token`
    - `maven-build-project-github-packages-enabled`
  - 'create-build-envs':
    - bash test script added to test action locally
  - 'build-maven-project':
    - make sure to unset extra maven environment variables after use so they are not available/exposed to subsequent actions
  - 'build-maven-project', 'create-build-envs' and 'run-maven-command':
    - use `env:` action input for multiline strings in
    - log less when loading helper script
    - bash helper script added

## Other changes
- chore: create-app-vars-matrix: test: support clean and handle errors
- chore: create-app-vars-matrix: log less when loading helper script
- chore: typos and .gitignore
- chore: require-build-envs: use `env:` action input for multiline strings
- chore: deploy-multiple-to-static-is-allowed: use `env:` action input for multiline strings
- chore: deploy-multiple-to-static: use `env:` action input for multiline strings
- chore: build-spring-boot-image: use `env:` action input for multiline strings
- chore: build-nodejs-project: use `env:` action input for multiline strings