### PR TITLE
Maven artifacts pruning

### DIFF
--- a/.github/workflows/ci-cd-build-deploy-maven-lib.yml
+++ b/.github/workflows/ci-cd-build-deploy-maven-lib.yml
@@ -5,10 +5,11 @@ name: "DSB Build and deploy Maven artefact"
 #   - vars.ORG_AZURE_CONTAINER_REGISTRY_USER  <-- username of user with push+pull access to ACR, passed to the azure/docker-login action
 #
 # The following secrets must be available in the github 'secrets' context:
-#   - secrets.ORG_MAVEN_REPO_TOKEN                            <-- token for maven repo user
-#   - secrets.ORG_SONAR_TOKEN                                 <-- token for sonar integration
-#   - secrets.ORG_JASYPT_LOCAL_ENCRYPTOR_PASSWORD             <-- jasypt password for local decryption of secrets during maven operations
-#   - secrets.ORG_AZURE_CONTAINER_REGISTRY_PASSWORD           <-- password of user with push+pull access to ACR, passed to the azure/docker-login action
+#   - secrets.ORG_AZURE_CONTAINER_REGISTRY_PASSWORD <-- password of user with push+pull access to ACR, passed to the azure/docker-login action
+#   - secrets.ORG_GITHUB_PACKAGES_ADMIN_PAT         <-- GitHub PAT with with scopes [delete:packages, read:packages] in the calling repos organization
+#   - secrets.ORG_JASYPT_LOCAL_ENCRYPTOR_PASSWORD   <-- jasypt password for local decryption of secrets during maven operations
+#   - secrets.ORG_MAVEN_REPO_TOKEN                  <-- token for maven repo user
+#   - secrets.ORG_SONAR_TOKEN                       <-- token for sonar integration
 
 on:
   workflow_call:
@@ -23,6 +24,33 @@ on:
             - application-type        - string, always 'maven-library'
           For optional fields see possible inputs to the create-build-envs action.
         required: true
+      # below are repo-specific settings, not app specific and thus does not belong in 'apps'
+      # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
+      # sane defaults are defined but can be overridden pr. repo
+      maven-artifacts-release-prune-keep-min-count:
+        type: number
+        required: false
+        default: 20
+      maven-artifacts-release-prune-keep-num-days:
+        type: number
+        required: false
+        default: 90
+      maven-artifacts-snapshot-prune-keep-min-count:
+        type: number
+        required: false
+        default: 0
+      maven-artifacts-snapshot-prune-keep-num-days:
+        type: number
+        required: false
+        default: 30
+      maven-artifacts-other-prune-keep-min-count:
+        type: number
+        required: false
+        default: 0
+      maven-artifacts-other-prune-keep-num-days:
+        type: number
+        required: false
+        default: 0
 
 jobs:
   create-matrix:
@@ -38,6 +66,7 @@ jobs:
       # The create-app-vars-matrix action requires source code to be available
       - name: 🧹 Clean workspace
         uses: dsb-norge/github-actions/directory-recreate@v2
+
       - name: ⬇ Checkout working branch
         uses: actions/checkout@v3
 
@@ -85,12 +114,40 @@ jobs:
         with:
           dsb-build-envs: ${{ steps.build-env.outputs.json }}
 
+  prune-maven-artifacts:
+    name: Prune maven artifacts
+    # This job handles pruning of maven artifacts published in the calling repo
+    # Run even in case of failure in previous jobs/steps, in an attempt to avoid scenarios where PR snapshots would not get deleted
+    # Skip step for pull request except to clean up snapshots when closing a PR
+    if: >-
+      ( success() || failure() )
+      &&
+      ( github.event_name != 'pull_request' || github.event.action == 'closed' )
+    needs: [create-matrix, build-and-deploy]
+    runs-on: [self-hosted, dsb-builder, linux, x64]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: 🗑 Prune maven artifacts
+        id: prune
+        # This check is required to block deploys when workflow is manually triggered from a non-default branch
+        uses: dsb-norge/github-actions/ci-cd/prune-maven-artifacts-in-repo@v2
+        with:
+          github-packages-token: ${{ secrets.ORG_GITHUB_PACKAGES_ADMIN_PAT }}
+          other-prune-keep-min-count: ${{ inputs.maven-artifacts-other-prune-keep-min-count }}
+          other-prune-keep-num-days: ${{ inputs.maven-artifacts-other-prune-keep-num-days }}
+          release-prune-keep-min-count: ${{ inputs.maven-artifacts-release-prune-keep-min-count }}
+          release-prune-keep-num-days: ${{ inputs.maven-artifacts-release-prune-keep-num-days }}
+          snapshot-prune-keep-min-count: ${{ inputs.maven-artifacts-snapshot-prune-keep-min-count }}
+          snapshot-prune-keep-num-days: ${{ inputs.maven-artifacts-snapshot-prune-keep-num-days }}
+
   # create a global result indicating if workflow steps succeeded or not,
   # handy for branch protection rules
   ci-cd-conclusion:
     if: always()
     name: ci-cd-conclusion
-    needs: [create-matrix, build-and-deploy]
+    needs: [create-matrix, build-and-deploy, prune-maven-artifacts]
     runs-on: [self-hosted, dsb-builder, linux, x64]
     defaults:
       run:

--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -10,13 +10,14 @@ name: "DSB Build, push and deploy"
 #   - vars.ORG_CICD_APP_INSTALLATION_ID       <-- app installation id found in url if you "configure" the app 'dsb-norge-cicd-access' from here: https://github.com/organizations/dsb-norge/settings/installations
 #
 # The following secrets must be available in the github 'secrets' context:
-#   - secrets.ORG_MAVEN_REPO_TOKEN                            <-- token for maven repo user
-#   - secrets.ORG_SONAR_TOKEN                                 <-- token for sonar integration
-#   - secrets.ORG_JASYPT_LOCAL_ENCRYPTOR_PASSWORD             <-- jasypt password for local decryption of secrets during maven operations
 #   - secrets.ORG_AZURE_CONTAINER_REGISTRY_PASSWORD           <-- password of user with push+pull access to ACR, passed to the azure/docker-login action
 #   - secrets.ORG_AZURE_CONTAINER_REGISTRY_SERVICE_PRINCIPAL  <-- service principal of Azure identity with delete access to ACR, passed to the azure/login actions and used for pruning in ACR
 #   - secrets.ORG_AZURE_DEV_AKS_CONTRIBUTOR_SERVICE_PRINCIPAL <-- service principal of Azure identity with contributor access to the AKS instance for ephemeral environments
 #   - secrets.ORG_CICD_APP_PRIVATE_KEY                        <-- generated from the app in github: https://github.com/organizations/dsb-norge/settings/apps/dsb-norge-cicd-access
+#   - secrets.ORG_GITHUB_PACKAGES_ADMIN_PAT                   <-- GitHub PAT with with scopes [delete:packages, read:packages] in the calling repos organization
+#   - secrets.ORG_JASYPT_LOCAL_ENCRYPTOR_PASSWORD             <-- jasypt password for local decryption of secrets during maven operations
+#   - secrets.ORG_MAVEN_REPO_TOKEN                            <-- token for maven repo user
+#   - secrets.ORG_SONAR_TOKEN                                 <-- token for sonar integration
 
 on:
   workflow_call:
@@ -30,6 +31,33 @@ on:
             - application-name        - string
           For optional fields see possible inputs to the create-build-envs action.
         required: true
+      # below are repo-specific settings, not app specific and thus does not belong in 'apps'
+      # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
+      # sane defaults are defined but can be overridden pr. repo
+      maven-artifacts-release-prune-keep-min-count:
+        type: number
+        required: false
+        default: 20
+      maven-artifacts-release-prune-keep-num-days:
+        type: number
+        required: false
+        default: 90
+      maven-artifacts-snapshot-prune-keep-min-count:
+        type: number
+        required: false
+        default: 0
+      maven-artifacts-snapshot-prune-keep-num-days:
+        type: number
+        required: false
+        default: 30
+      maven-artifacts-other-prune-keep-min-count:
+        type: number
+        required: false
+        default: 0
+      maven-artifacts-other-prune-keep-num-days:
+        type: number
+        required: false
+        default: 0
 
 jobs:
   create-matrix:
@@ -60,7 +88,7 @@ jobs:
     runs-on: [self-hosted, dsb-builder, linux, x64]
     strategy:
       matrix: ${{ fromJSON(needs.create-matrix.outputs.app-vars-matrix) }}
-      fail-fast: false # allow all paralell jobs to continiue even if one fails
+      fail-fast: false # allow all paralell jobs to continue even if one fails
     defaults:
       run:
         shell: bash
@@ -255,12 +283,40 @@ jobs:
               sha: context.sha
             })
 
+  prune-maven-artifacts:
+    name: Prune maven artifacts
+    # This job handles pruning of maven artifacts published in the calling repo
+    # Run even in case of failure in previous jobs/steps, in an attempt to avoid scenarios where PR snapshots would not get deleted
+    # Skip step for pull request except to clean up snapshots when closing a PR
+    if: >-
+      ( success() || failure() )
+      &&
+      ( github.event_name != 'pull_request' || github.event.action == 'closed' )
+    needs: [create-matrix, build-deploy]
+    runs-on: [self-hosted, dsb-builder, linux, x64]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: 🗑 Prune maven artifacts
+        id: prune
+        # This check is required to block deploys when workflow is manually triggered from a non-default branch
+        uses: dsb-norge/github-actions/ci-cd/prune-maven-artifacts-in-repo@v2
+        with:
+          github-packages-token: ${{ secrets.ORG_GITHUB_PACKAGES_ADMIN_PAT }}
+          other-prune-keep-min-count: ${{ inputs.maven-artifacts-other-prune-keep-min-count }}
+          other-prune-keep-num-days: ${{ inputs.maven-artifacts-other-prune-keep-num-days }}
+          release-prune-keep-min-count: ${{ inputs.maven-artifacts-release-prune-keep-min-count }}
+          release-prune-keep-num-days: ${{ inputs.maven-artifacts-release-prune-keep-num-days }}
+          snapshot-prune-keep-min-count: ${{ inputs.maven-artifacts-snapshot-prune-keep-min-count }}
+          snapshot-prune-keep-num-days: ${{ inputs.maven-artifacts-snapshot-prune-keep-num-days }}
+
   # create a global result indicating if workflow steps succeeded or not,
   # handy for branch protection rules
   ci-cd-conclusion:
     if: always()
     name: ci-cd-conclusion
-    needs: [create-matrix, build-deploy, deploy-to-static]
+    needs: [create-matrix, build-deploy, deploy-to-static, prune-maven-artifacts]
     runs-on: [self-hosted, dsb-builder, linux, x64]
     defaults:
       run:

--- a/.github/workflows/maven-artifacts-pruner.yml
+++ b/.github/workflows/maven-artifacts-pruner.yml
@@ -1,0 +1,76 @@
+name: "DSB retention policy for maven artifacts in gitHub packages"
+
+# The following secrets must be available in the github 'secrets' context:
+#   - secrets.ORG_GITHUB_PACKAGES_ADMIN_PAT         <-- GitHub PAT with with scopes [delete:packages, read:packages] in the calling repos organization
+
+on:
+  workflow_call:
+    inputs:
+      # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
+      # sane defaults are defined but can be overridden pr. repo
+      release-prune-keep-min-count:
+        type: number
+        required: false
+        default: 20
+      release-prune-keep-num-days:
+        type: number
+        required: false
+        default: 90
+      snapshot-prune-keep-min-count:
+        type: number
+        required: false
+        default: 0
+      snapshot-prune-keep-num-days:
+        type: number
+        required: false
+        default: 30
+      other-prune-keep-min-count:
+        type: number
+        required: false
+        default: 0
+      other-prune-keep-num-days:
+        type: number
+        required: false
+        default: 0
+
+jobs:
+  prune-maven-artifacts:
+    name: Prune maven artifacts
+    # This job handles pruning of maven artifacts published in the calling repo
+    runs-on: [self-hosted, dsb-builder, linux, x64]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: 🗑 Prune maven artifacts
+        id: prune
+        # This check is required to block deploys when workflow is manually triggered from a non-default branch
+        uses: dsb-norge/github-actions/ci-cd/prune-maven-artifacts-in-repo@v2
+        with:
+          github-packages-token: ${{ secrets.ORG_GITHUB_PACKAGES_ADMIN_PAT }}
+          other-prune-keep-min-count: ${{ inputs.other-prune-keep-min-count }}
+          other-prune-keep-num-days: ${{ inputs.other-prune-keep-num-days }}
+          release-prune-keep-min-count: ${{ inputs.release-prune-keep-min-count }}
+          release-prune-keep-num-days: ${{ inputs.release-prune-keep-num-days }}
+          snapshot-prune-keep-min-count: ${{ inputs.snapshot-prune-keep-min-count }}
+          snapshot-prune-keep-num-days: ${{ inputs.snapshot-prune-keep-num-days }}
+
+  # create a global result indicating if workflow steps succeeded or not,
+  # handy for branch protection rules
+  ci-cd-conclusion:
+    if: always()
+    name: ci-cd-conclusion
+    needs: [prune-maven-artifacts]
+    runs-on: [self-hosted, dsb-builder, linux, x64]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - run: exit 1
+        # for explanation of '>-' below see https://stackoverflow.com/a/67532120/4907315
+        # job 'result': possible values are 'success', 'failure', 'cancelled', or 'skipped'
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}

--- a/.github/workflows/maven-versions-bumper.yml
+++ b/.github/workflows/maven-versions-bumper.yml
@@ -37,6 +37,7 @@ jobs:
       # The create-app-vars-matrix action requires source code to be available
       - name: 🧹 Clean workspace
         uses: dsb-norge/github-actions/directory-recreate@v2
+
       - name: ⬇ Checkout working branch
         uses: actions/checkout@v3
 
@@ -53,11 +54,9 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.create-matrix.outputs.app-vars-matrix) }}
       fail-fast: false # allow all parallel jobs to continue even if one fails
-
     defaults:
       run:
         shell: bash
-
     steps:
       - name: 🧹 Clean workspace
         uses: dsb-norge/github-actions/directory-recreate@v2

--- a/ci-cd/prune-images-from-acr/action.yml
+++ b/ci-cd/prune-images-from-acr/action.yml
@@ -33,7 +33,7 @@ runs:
         creds: ${{ fromJSON(inputs.dsb-build-envs).acr-service-principal }}
         allow-no-subscriptions: true
 
-    # perforn delete
+    # perform delete
     - shell: bash
       run: |
         # Delete images from ACR

--- a/ci-cd/prune-maven-artifacts-in-repo/action.yml
+++ b/ci-cd/prune-maven-artifacts-in-repo/action.yml
@@ -1,0 +1,461 @@
+name: "Prune maven artifacts from GitHub packages of the calling repo"
+description: |
+  Performs pruning of maven artifacts (stored in GitHub packages) of the calling repo.
+  Depending on the version name of the maven artifacts they are grouped into 3 'types': release, snapshot and other.
+  Each of the 3 groups of artifacts will have different retention polices applied depending on the input values of the action.
+  Overall mode of operation:
+    1. Retrieve all GitHub packages of type 'maven' of the calling repo using the GitHub API via GitHub CLI.
+    2. Group the maven packages based on version name. See details further down about how version name affects grouping.
+    3. Consider versions of each package for pruning. See details further down about how/when each type is considered.
+    4. If all versions of a package is scheduled for deletion, delete the whole package from GitHub packages.
+    5. If any versions of a package is scheduled for deletion (but not all versions), delete each of the versions.
+author: "Peder Schmedling"
+inputs:
+  # Maven artifacts are considered 'release' when their version matches DSB versioning scheme '[YY]YY.MM.DD.SSSSS'.
+  # Maven 'release' artifacts for all packages of a given repo will be pruned according to 'release-prune-keep-*' below.
+  # Maven 'release' artifacts ar not considered for pruning when the action is called from PR events.
+  release-prune-keep-min-count:
+    description: |
+      Minimum number of maven release artifacts to always keep for each package. No matter the age of the package.
+    required: true
+  release-prune-keep-num-days:
+    description: |
+      Maven release artifacts will not be considered for pruning until this number of days has passed since they where last updated.
+    required: true
+  # Maven artifacts are considered 'snapshot' when their version matches DSB PR snapshot versioning scheme 'PR-[NUM]-SNAPSHOT'.
+  # Maven 'snapshot' artifacts are not pruned during the lifetime of a PR.
+  # Maven 'snapshot' artifacts are belonging to a specific PR will be deleted when the PR is merged or otherwise closed.
+  # ADDITIONALLY:
+  #   The 'snapshot-prune-keep-*' settings below affects how Maven 'snapshot' artifacts for the repo as a whole are pruned.
+  #   This happens when this action is called from a non-PR event (eg. 'merge', 'workflow_dispatch' etc.).
+  snapshot-prune-keep-min-count:
+    description: |
+      Minimum number of maven snapshot artifacts to keep for each package. No matter the age of the package.
+    required: true
+  snapshot-prune-keep-num-days:
+    description: |
+      Maven snapshot artifacts will not be considered for pruning until this number of days has passed since they where last updated.
+    required: true
+  # Maven artifacts are considered as 'other' if they are not considered as 'release' or 'snapshot'.
+  # Maven 'other' artifacts for all packages of a given repo will be pruned according to 'other-prune-keep-*' below.
+  # Maven 'other' artifacts ar not considered for pruning when the action is called from PR events.
+  other-prune-keep-min-count:
+    description: |
+      Minimum number of other maven artifacts to keep for each package. No matter the age of the package.
+    required: true
+  other-prune-keep-num-days:
+    description: |
+      Other Maven artifacts will not be considered for pruning until this number of days has passed since they where last updated.
+    required: true
+  github-packages-token:
+    description: |
+      GitHub Personal Access Token (PAT) with scopes [delete:packages, read:packages] in the calling repos organization.
+    required: true
+runs:
+  using: "composite"
+  steps:
+    # get all packages of the calling repo including their versions
+    - id: get-packages-and-versions
+      env:
+        PACKAGE_TYPE: "maven"
+        GH_TOKEN: ${{ inputs.github-packages-token }}
+      shell: bash
+      run: |
+        # Use github API from github CLI to retrieve repo packages and their versions
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        log-info "Read repo packages:"
+        PACKAGES_RESPONSE=$(
+          gh api \
+            --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/orgs/${GITHUB_REPOSITORY_OWNER}/packages?package_type=${PACKAGE_TYPE}&per_page=100" \
+            --jq "map(select(.repository.full_name == \"${GITHUB_REPOSITORY}\"))"
+        )
+
+        PACKAGES_JSON=$(echo "${PACKAGES_RESPONSE}" | jq -s '. | flatten')
+        PACKAGE_COUNT=$(echo "$PACKAGES_JSON" | jq -r '. | length')
+        PACKAGE_NAMES=$(echo "$PACKAGES_JSON" | jq -r '. | .[].name' | sort)
+
+        if [ "${PACKAGE_COUNT}" == '0' ]; then
+          log-info "  The repo '${GITHUB_REPOSITORY}' has no packages of type '${PACKAGE_TYPE}'."
+        else
+          log-multiline "${PACKAGE_COUNT} package(s) of type '${PACKAGE_TYPE}' in the repo '${GITHUB_REPOSITORY}'" "${PACKAGE_NAMES}"
+        fi
+
+        OUTPUT_JSON='{}'
+        for PACKAGE_NAME in ${PACKAGE_NAMES}; do
+          log-info "  Read repo package '${PACKAGE_NAME}' ...:"
+          PACKAGE_VERSIONS_COUNT=$(echo "$PACKAGES_JSON" | jq -r --arg packagename "${PACKAGE_NAME}" '. | select(.[].name == $packagename) | .[0].version_count')
+
+          PACKAGE_VERSIONS=$(
+            gh api \
+              --paginate \
+              -H "Accept: application/vnd.github+json" \
+              "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/${PACKAGE_TYPE}/${PACKAGE_NAME}/versions?per_page=100"
+          )
+
+          PACKAGE_VERSIONS_FOUND_COUNT=$(echo "${PACKAGE_VERSIONS}" | jq '. | length')
+          if [ ! "${PACKAGE_VERSIONS_FOUND_COUNT}" == "${PACKAGE_VERSIONS_COUNT}" ]; then
+            log-error "GitHub API returned ${PACKAGE_VERSIONS_FOUND_COUNT} versions for the package '${PACKAGE_NAME}, ${PACKAGE_VERSIONS_COUNT} was expected!"
+            exit 1
+          elif [ "${PACKAGE_VERSIONS_FOUND_COUNT}" == '0' ]; then
+            log-info "  No versions found for the package '${PACKAGE_NAME}'."
+          else
+            start-group "Found ${PACKAGE_VERSIONS_FOUND_COUNT} version(s):"
+
+            PACKAGE_VERSIONS_GROUPED=$(
+              echo "${PACKAGE_VERSIONS}" |
+                jq \
+                  --arg packagename "${PACKAGE_NAME}" \
+                  --arg packagetype "${PACKAGE_TYPE}" \
+                  '
+                  (.) as $data
+                  | ($data | map(select(.name | ascii_upcase | test("^\\d{2}(\\d{2})?\\.\\d{2}\\.\\d{2}\\.\\d{1,5}$") )) | sort_by(.updated_at) ) as $releases
+                  | ($data | map(select(.name | ascii_upcase | test("^PR-\\d+-SNAPSHOT$") ))                             | sort_by(.updated_at) ) as $snapshots
+                  | ($data | map(select(
+                      (.name | ascii_upcase | test("^\\d{2}(\\d{2})?\\.\\d{2}\\.\\d{2}\\.\\d{1,5}$") | not)
+                      and (.name | ascii_upcase | test("^PR-\\d+-SNAPSHOT$") | not)
+                    )) | sort_by(.updated_at) ) as $others
+                  | { ($packagename) : {
+                    "type":      $packagetype,
+                    "releases":  { "count": ($releases  | length), "versions": $releases  },
+                    "snapshots": { "count": ($snapshots | length), "versions": $snapshots },
+                    "others":    { "count": ($others    | length), "versions": $others    },
+                  } }'
+            )
+
+            log-info " - releases  : $(echo "${PACKAGE_VERSIONS_GROUPED}" | jq --arg packagename "${PACKAGE_NAME}" '. | .[$packagename].releases.count | length')"
+            log-info " - snapshots : $(echo "${PACKAGE_VERSIONS_GROUPED}" | jq --arg packagename "${PACKAGE_NAME}" '. | .[$packagename].snapshots.count | length')"
+            log-info " - other     : $(echo "${PACKAGE_VERSIONS_GROUPED}" | jq --arg packagename "${PACKAGE_NAME}" '. | .[$packagename].others.count | length')"
+
+            end-group
+
+            OUTPUT_JSON=$(echo "${OUTPUT_JSON}" | jq --argjson packagejson "${PACKAGE_VERSIONS_GROUPED}" '.+ $packagejson')
+
+          fi
+        done # loop PACKAGE_NAMES
+
+        log-multiline "${PACKAGE_TYPE} packages JSON for repo" "${OUTPUT_JSON}"
+
+        TOTAL_VERSIONS_COUNT=$(echo "${OUTPUT_JSON}" | jq '. | map(.releases.count + .snapshots.count + .others.count) | add')
+
+        echo "total-versions-count=${TOTAL_VERSIONS_COUNT}" >> $GITHUB_OUTPUT
+
+        echo 'json<<"${{ github.run_id }}"' >> $GITHUB_OUTPUT
+        echo "${OUTPUT_JSON}" >> $GITHUB_OUTPUT
+        echo '"${{ github.run_id }}"' >> $GITHUB_OUTPUT
+
+    # parse repo packages + versions to determine versions and packages to delete
+    - id: get-what-to-delete
+      # skip this step if there are no package versions to evaluate for pruning
+      if: steps.get-packages-and-versions.outputs.total-versions-count > 0
+      env:
+        PACKAGES_JSON: "${{ steps.get-packages-and-versions.outputs.json }}"
+        KEEP_RELEASES_COUNT: ${{ inputs.release-prune-keep-min-count }}
+        KEEP_RELEASES_DAYS: ${{ inputs.release-prune-keep-num-days }}
+        KEEP_SNAPSHOTS_COUNT: ${{ inputs.snapshot-prune-keep-min-count }}
+        KEEP_SNAPSHOTS_DAYS: ${{ inputs.snapshot-prune-keep-num-days }}
+        KEEP_OTHERS_COUNT: ${{ inputs.other-prune-keep-min-count }}
+        KEEP_OTHERS_DAYS: ${{ inputs.other-prune-keep-num-days }}
+        PR_NUMBER: ${{ github.event.number }}
+        IS_PR: ${{ github.event_name == 'pull_request' }}
+        CLOSING_PR: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+      shell: bash
+      run: |
+        # Determine versions and packages to delete
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        # will contain version types to be considered for pruning.
+        declare -a CONSIDER_VERSION_TYPES
+
+        if ${IS_PR}; then
+          if ${CLOSING_PR}; then
+            log-info "Called from a closing PR, snapshots will be deleted not pruned."
+
+            # always delete PR snapshots when closing a PR
+            KEEP_SNAPSHOTS_COUNT=0
+            KEEP_SNAPSHOTS_DAYS=0
+            CONSIDER_VERSION_TYPES+=(snapshots)
+
+            # additional filter to look only for snapshots from the calling PR
+            PR_SNAPSHOT_NAME="PR-${PR_NUMBER}-SNAPSHOT"
+            JQ_FILTER_CANDIDATES=". | map(select( .name | ascii_upcase | test(\"^${PR_SNAPSHOT_NAME}\$\") ))"
+          else
+            log-info "Called from PR but not a closing action, nothing will not be considered for pruning."
+          fi
+        else
+          # not PR consider releases and others for pruning
+          log-info "Not called from a PR."
+          CONSIDER_VERSION_TYPES+=(releases snapshots others)
+
+          # no additional filtering in this case, ie. ALL snapshots in repo will be considered
+          JQ_FILTER_CANDIDATES=''
+        fi
+
+        # easier access to config further down
+        declare -A PRUNE_CONFIG
+        PRUNE_CONFIG[releases, count]="${KEEP_RELEASES_COUNT}"
+        PRUNE_CONFIG[releases, days]="${KEEP_RELEASES_DAYS}"
+        PRUNE_CONFIG[snapshots, count]="${KEEP_SNAPSHOTS_COUNT}"
+        PRUNE_CONFIG[snapshots, days]="${KEEP_SNAPSHOTS_DAYS}"
+        PRUNE_CONFIG[others, count]="${KEEP_OTHERS_COUNT}"
+        PRUNE_CONFIG[others, days]="${KEEP_OTHERS_DAYS}"
+
+        # these arrays will be the outputs of this step
+        PACKAGES_TO_DELETE='[]'
+        VERSIONS_TO_DELETE='[]'
+
+        if [[ "${#CONSIDER_VERSION_TYPES[@]}" == '0' ]]; then
+          log-info "No package type(s) are being considered for pruning."
+        else
+          log-info "Versions of the following package type(s) are being considered: ${CONSIDER_VERSION_TYPES[*]}"
+
+          # loop all packages and evaluate pruning of versions for each
+          PACKAGE_NAMES=$(echo "${PACKAGES_JSON}" | jq -r '. | keys | .[]')
+          for PACKAGE_NAME in ${PACKAGE_NAMES}; do
+            start-group "Package '${PACKAGE_NAME}':"
+
+            PACKAGE_VERSION_COUNT=$(echo "${PACKAGES_JSON}" | jq -r --arg packagename "${PACKAGE_NAME}" '.[$packagename] | .releases.count + .snapshots.count + .others.count')
+            PACKAGE_TYPE=$(echo "${PACKAGES_JSON}" | jq -r --arg packagename "${PACKAGE_NAME}" '.[$packagename] | .type')
+
+            log-info " Total version(s) of package: ${PACKAGE_VERSION_COUNT}"
+            log-info " Package type: ${PACKAGE_TYPE}"
+
+            # all versions of the package to be deleted are appended to this array
+            PACKAGE_DISCARD_VERSIONS='[]'
+
+            # loop over the version types to evaluate, ie. releases, snapshots and/or others
+            for VERSION_TYPE in "${CONSIDER_VERSION_TYPES[@]}"; do
+
+              log-info " ${VERSION_TYPE}:"
+              KEEP_COUNT="${PRUNE_CONFIG[${VERSION_TYPE}, count]}"
+              KEEP_DAYS="${PRUNE_CONFIG[${VERSION_TYPE}, days]}"
+
+              log-info "  - Keep count: ${KEEP_COUNT}"
+              log-info "  - Min days to keep: ${KEEP_DAYS}"
+
+              # get candidates for pruning
+              CONSIDER_VERSIONS="$(
+                echo "${PACKAGES_JSON}" |
+                  jq \
+                    --arg packagename "${PACKAGE_NAME}" \
+                    --arg versiontype "${VERSION_TYPE}" \
+                    '.[$packagename] | .[$versiontype] | .versions'
+              )"
+
+              # additional filtering of candidates required?
+              if [ ! "${JQ_FILTER_CANDIDATES}" == '' ]; then
+                CONSIDER_VERSIONS="$(echo "${CONSIDER_VERSIONS}" | jq "${JQ_FILTER_CANDIDATES}")"
+              fi
+              CONSIDER_VERSIONS_COUNT=$(echo "${CONSIDER_VERSIONS}" | jq 'length')
+
+              # look for versions to discard
+              PRUNE_BEFORE_EPOCH=$(date +%s -d "${KEEP_DAYS} days ago")
+              DISCARD_VERSIONS=$(
+                echo "${CONSIDER_VERSIONS}" |
+                  # using --argjson to make sure keep_count is treated as number
+                  jq \
+                    --argjson count "${KEEP_COUNT}" \
+                    --argjson cutoff_epoch "${PRUNE_BEFORE_EPOCH}" \
+                    'sort_by(.updated_at) | reverse | .[$count:] | map(select( .updated_at | fromdateiso8601 < $cutoff_epoch ))'
+              )
+
+              DISCARD_VERSIONS_COUNT=$(echo "${DISCARD_VERSIONS}" | jq 'length')
+              log-info "  - ${DISCARD_VERSIONS_COUNT} of ${CONSIDER_VERSIONS_COUNT} ${VERSION_TYPE} should be discarded"
+
+              # append to array of all versions to delete for given package
+              PACKAGE_DISCARD_VERSIONS="$( (
+                echo "${PACKAGE_DISCARD_VERSIONS}"
+                echo "${DISCARD_VERSIONS}"
+              ) | jq '. + input')"
+
+            done # loop CONSIDER_VERSION_TYPES
+
+            # the number of versions to delete for given package
+            PACKAGE_DISCARD_VERSIONS_COUNT=$(echo "${PACKAGE_DISCARD_VERSIONS}" | jq -r 'length')
+            log-info " Total: ${PACKAGE_DISCARD_VERSIONS_COUNT} out of ${PACKAGE_VERSION_COUNT} version(s) scheduled for deletion."
+
+            # append to output as necessary
+            # note that we craft custom JSON objects containing all information required to perform the delete operation later on
+            if [ "${PACKAGE_VERSION_COUNT}" == "${PACKAGE_DISCARD_VERSIONS_COUNT}" ]; then
+              # not possible to delete all versions of a package, the package should be deleted instead
+              log-info " The package '${PACKAGE_NAME}' will be deleted as all versions of the package are scheduled for deletion."
+
+              # append to packages to delete output
+              PACKAGES_TO_DELETE="$(
+                echo "${PACKAGES_TO_DELETE}" | jq \
+                  --arg org "${GITHUB_REPOSITORY_OWNER}" \
+                  --arg packagetype "${PACKAGE_TYPE}" \
+                  --arg packagename "${PACKAGE_NAME}" \
+                  '. + [{
+                    "org": $org,
+                    "package_type": $packagetype,
+                    "package_name": $packagename,
+                  }]'
+              )"
+            else
+              # append to versions to delete output
+              VERSIONS_TO_DELETE="$(
+                (
+                  echo "${VERSIONS_TO_DELETE}"
+                  echo "${PACKAGE_DISCARD_VERSIONS}"
+                ) | jq \
+                  --arg org "${GITHUB_REPOSITORY_OWNER}" \
+                  --arg packagename "${PACKAGE_NAME}" \
+                  '. + (
+                    input
+                    | map({
+                      "org": $org,
+                      "package_type": .metadata.package_type,
+                      "package_name": $packagename,
+                      "package_version_id": .id,
+                      "package_version_name": .name,
+                      "package_version_updated_at": .updated_at,
+                    })
+                  )'
+              )"
+            fi
+
+            end-group
+
+          done # loop PACKAGE_NAMES
+
+        fi # got types to consider
+
+        PACKAGES_TO_DELETE_COUNT=$(echo "${PACKAGES_TO_DELETE}" | jq -r 'length')
+        if [ "${PACKAGES_TO_DELETE_COUNT}" == '0' ]; then
+          log-info "No packages will be deleted."
+        else
+          log-multiline "${PACKAGES_TO_DELETE_COUNT} package(s) will be deleted" "${PACKAGES_TO_DELETE}"
+        fi
+
+        VERSIONS_TO_DELETE_COUNT=$(echo "${VERSIONS_TO_DELETE}" | jq -r 'length')
+        if [ "${VERSIONS_TO_DELETE_COUNT}" == '0' ]; then
+          log-info "No package versions will be deleted."
+        else
+          log-multiline "${VERSIONS_TO_DELETE_COUNT} package version(s) will be deleted" "${VERSIONS_TO_DELETE}"
+        fi
+
+        echo "delete-packages-count=${PACKAGES_TO_DELETE_COUNT}" >> $GITHUB_OUTPUT
+        echo "delete-versions-count=${VERSIONS_TO_DELETE_COUNT}" >> $GITHUB_OUTPUT
+
+        echo 'delete-packages-json<<"${{ github.run_id }}"' >> $GITHUB_OUTPUT
+        echo "${PACKAGES_TO_DELETE}" >> $GITHUB_OUTPUT
+        echo '"${{ github.run_id }}"' >> $GITHUB_OUTPUT
+
+        echo 'delete-versions-json<<"${{ github.run_id }}"' >> $GITHUB_OUTPUT
+        echo "${VERSIONS_TO_DELETE}" >> $GITHUB_OUTPUT
+        echo '"${{ github.run_id }}"' >> $GITHUB_OUTPUT
+
+    - id: delete-packages
+      # skip this step if there are no packages to delete
+      if: steps.get-what-to-delete.outputs.delete-packages-count > 0
+      env:
+        PACKAGES_TO_DELETE: "${{ steps.get-what-to-delete.outputs.delete-packages-json }}"
+        GH_TOKEN: ${{ inputs.github-packages-token }}
+      shell: bash
+      run: |
+        # Delete package(s)
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        # loop and delete one at a time, postpone failing on error until end
+        start-group "Deleting packages ..."
+        declare -A GH_CLI_EXITCODES
+        while IFS= read -r GITHUB_ORG &&
+          IFS= read -r PACKAGE_TYPE &&
+          IFS= read -r PACKAGE_NAME; do
+
+          log-info "Deleting ${PACKAGE_TYPE} package named '${PACKAGE_NAME}' ..."
+          set +e
+          gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            "/orgs/${GITHUB_ORG}/packages/${PACKAGE_TYPE}/${PACKAGE_NAME}"
+          GH_CLI_EXITCODE=${?}
+          set -e
+          GH_CLI_EXITCODES[${PACKAGE_NAME}]="${GH_CLI_EXITCODE}"
+          if [ "${GH_CLI_EXITCODE}" == "0" ]; then
+            log-info "Done."
+          else
+            log-error "GitHub CLI failed during delete operation with code '${GH_CLI_EXITCODE}'!"
+          fi
+        done < <(
+          jq -r '.[] | (
+            .org,
+            .package_type,
+            .package_name
+          )' <<<"${PACKAGES_TO_DELETE}"
+        )
+        end-group
+
+        # exit with sum of exit codes
+        GH_CLI_SUM_EXIT_CODES=$(
+          IFS=+
+          echo "$((${GH_CLI_EXITCODES[*]}))"
+        )
+        exit ${GH_CLI_SUM_EXIT_CODES}
+
+    - id: delete-versions
+      # skip this step if there are no versions to delete
+      # run step even if package delete fails (but not when package delete was 'cancelled')
+      if: >-
+        steps.get-what-to-delete.outputs.delete-versions-count > 0 && (
+             steps.delete-packages.conclusion == 'success'
+          || steps.delete-packages.conclusion == 'failure'
+          || steps.delete-packages.conclusion == 'skipped'
+        )
+      env:
+        VERSIONS_TO_DELETE: "${{ steps.get-what-to-delete.outputs.delete-versions-json }}"
+        GH_TOKEN: ${{ inputs.github-packages-token }}
+      shell: bash
+      run: |
+        # Delete version(s)
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        # loop and delete one at a time, postpone failing on error until end
+        start-group "Deleting package versions ..."
+        declare -A GH_CLI_EXITCODES
+        while IFS= read -r GITHUB_ORG &&
+          IFS= read -r PACKAGE_TYPE &&
+          IFS= read -r PACKAGE_NAME &&
+          IFS= read -r VERSION_ID &&
+          IFS= read -r VERSION_NAME &&
+          IFS= read -r VERSION_UPDATED_AT; do
+
+          log-info "Deleting version '${VERSION_NAME}' last updated ${VERSION_UPDATED_AT} ..."
+          set +e
+          gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            "/orgs/${GITHUB_ORG}/packages/${PACKAGE_TYPE}/${PACKAGE_NAME}/versions/${VERSION_ID}"
+          GH_CLI_EXITCODE=${?}
+          set -e
+          GH_CLI_EXITCODES[${VERSION_ID}]="${GH_CLI_EXITCODE}"
+          if [ "${GH_CLI_EXITCODE}" == "0" ]; then
+            log-info "Done."
+          else
+            log-error "GitHub CLI failed during delete operation with code '${GH_CLI_EXITCODE}'!"
+          fi
+        done < <(
+          jq -r '.[] | (
+            .org,
+            .package_type,
+            .package_name,
+            .package_version_id,
+            .package_version_name,
+            .package_version_updated_at
+          )' <<<"${VERSIONS_TO_DELETE}"
+        )
+        end-group
+
+        # exit with sum of exit codes
+        GH_CLI_SUM_EXIT_CODES=$(
+          IFS=+
+          echo "$((${GH_CLI_EXITCODES[*]}))"
+        )
+        exit ${GH_CLI_SUM_EXIT_CODES}

--- a/ci-cd/prune-maven-artifacts-in-repo/helpers.sh
+++ b/ci-cd/prune-maven-artifacts-in-repo/helpers.sh
@@ -1,0 +1,26 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name='prune-maven-artifacts-in-repo'
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+function set-output { echo "${1}=${2}" >> $GITHUB_OUTPUT; }
+
+# working with JSON array input
+function get-first-val { echo "${JSON_ARRAY}" | jq -r --arg name "${1}" '. | map(.[$name] | select( . != null ))  | first // empty'; }
+
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."


### PR DESCRIPTION
# new features

## new action `prune-maven-artifacts-in-repo`
Performs pruning of maven artifacts (stored in GitHub packages) of the calling repo. Depending on the version name of the maven artifacts they are grouped into 3 'types': release, snapshot and other. Each of the 3 groups of artifacts will have different retention polices applied depending on the input values of the action.

Overall mode of operation:
1. Retrieve all GitHub packages of type 'maven' of the calling repo using the GitHub API via GitHub CLI.
2. Group the maven packages based on version name.
3. Consider versions of each package for pruning.
4. If all versions of a package is scheduled for deletion, delete the whole package from GitHub packages.
5. If any versions of a package is scheduled for deletion (but not all versions), delete each of the versions.

## ci/cd workflows: prune maven artifacts:
- For the two existing ci/cd workflows `ci-cd-default` and `ci-cd-build-deploy-maven-lib`:
  - Call the new action `prune-maven-artifacts-in-repo` by default.
  - Introduce sane defaults for maven artifacts pruning configuration. These can be overridden in the calling workflow.
    - Release artifacts:
      - Always keep the last 20 published
      - If there are more than 20 total, those older than 90 days will be deleted
    - Snapshot artifacts:
      - Snapshots belonging to a PR are deleted when the PR is closed
      - In the case of long lived PRs: any snapshot older than 30 days in the repo will be deleted
    - Other artifacts (i.e. maven packages not considered release or snapshot):
      - Always delete all of these

## new workflow `maven-artifacts-pruner`:
- Standalone re-usable workflow that can be called from any repo with maven artifacts (stored in GitHub packages).
- This will typically be used by repos that does not call any of the standard ci/cd workflows.
