### PR TITLE
More on local storage of dependencies on runners

### DIFF
--- a/.github/workflows/ci-cd-build-deploy-maven-lib.yml
+++ b/.github/workflows/ci-cd-build-deploy-maven-lib.yml
@@ -64,7 +64,7 @@ jobs:
       applications-version: ${{ steps.create-matrix.outputs.applications-version }}
     steps:
       # The create-app-vars-matrix action requires source code to be available
-      - name: 🧹 Clean workspace
+      - name: "🧹 Clean: 🏢 workspace"
         id: clean
         uses: dsb-norge/github-actions/directory-recreate@v2
 
@@ -88,15 +88,21 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: 🧹 Clean workspace
+      - name: "🧹 Clean: 🏢 workspace"
         id: clean
         uses: dsb-norge/github-actions/directory-recreate@v2
 
-      # we have enabled maven repo caching with the 'actions/setup-java' action
+      # we have enabled caching with the 'actions/setup-java' action
       # this prevents the local repo/cache from growing during the lifetime of our self hosted runners
-      - name: 🧹 Clean local maven repo
+      - name: "🧹 Clean: 🗄️ local maven repo"
         id: clean-maven-repo
         uses: dsb-norge/github-actions/ci-cd/clear-local-maven-repo@v2
+
+      # we have enabled caching with the 'actions/setup-node' action
+      # this prevents the local repo/cache from growing during the lifetime of our self hosted runners
+      - name: "🧹 Clean: 📚 local npm cache"
+        id: clean-npm-cache
+        uses: dsb-norge/github-actions/ci-cd/clear-local-npm-cache@v2
 
       - name: ⬇ Checkout working branch
         id: checkout

--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -97,6 +97,12 @@ jobs:
         id: clean
         uses: dsb-norge/github-actions/directory-recreate@v2
 
+      # we have enabled caching with the 'actions/setup-java' action
+      # this prevents the local repo/cache from growing during the lifetime of our self hosted runners
+      - name: "🧹 Clean: 🗄️ local maven repo"
+        id: clean-maven-repo
+        uses: dsb-norge/github-actions/ci-cd/clear-local-maven-repo@v2
+
       - name: ⬇ Checkout working branch
         id: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -252,12 +252,6 @@ jobs:
         id: clean
         uses: dsb-norge/github-actions/directory-recreate@v2
 
-      # we have enabled maven repo caching with the 'actions/setup-java' action
-      # this prevents the local repo/cache from growing during the lifetime of our self hosted runners
-      - name: 🧹 Clean local maven repo
-        id: clean-maven-repo
-        uses: dsb-norge/github-actions/ci-cd/clear-local-maven-repo@v2
-
       - name: ⬇ Checkout working branch
         id: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -71,8 +71,10 @@ jobs:
       applications-version: ${{ steps.create-matrix.outputs.applications-version }}
     steps:
       # The create-app-vars-matrix action requires source code to be available
-      - name: 🧹 Clean workspace
+      - name: "🧹 Clean: 🏢 workspace"
+        id: clean
         uses: dsb-norge/github-actions/directory-recreate@v2
+
       - name: ⬇ Checkout working branch
         uses: actions/checkout@v3
 
@@ -93,7 +95,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: 🧹 Clean workspace
+      - name: "🧹 Clean: 🏢 workspace"
         id: clean
         uses: dsb-norge/github-actions/directory-recreate@v2
 
@@ -102,6 +104,12 @@ jobs:
       - name: "🧹 Clean: 🗄️ local maven repo"
         id: clean-maven-repo
         uses: dsb-norge/github-actions/ci-cd/clear-local-maven-repo@v2
+
+      # we have enabled caching with the 'actions/setup-node' action
+      # this prevents the local repo/cache from growing during the lifetime of our self hosted runners
+      - name: "🧹 Clean: 📚 local npm cache"
+        id: clean-npm-cache
+        uses: dsb-norge/github-actions/ci-cd/clear-local-npm-cache@v2
 
       - name: ⬇ Checkout working branch
         id: checkout
@@ -248,7 +256,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: 🧹 Clean workspace
+      - name: "🧹 Clean: 🏢 workspace"
         id: clean
         uses: dsb-norge/github-actions/directory-recreate@v2
 

--- a/.github/workflows/maven-versions-bumper.yml
+++ b/.github/workflows/maven-versions-bumper.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       # The create-app-vars-matrix action requires source code to be available
-      - name: 🧹 Clean workspace
+      - name: "🧹 Clean: 🏢 workspace"
         id: clean
         uses: dsb-norge/github-actions/directory-recreate@v2
 
@@ -60,15 +60,21 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: 🧹 Clean workspace
+      - name: "🧹 Clean: 🏢 workspace"
         id: clean
         uses: dsb-norge/github-actions/directory-recreate@v2
 
-      # we have enabled maven repo caching with the 'actions/setup-java' action
+      # we have enabled caching with the 'actions/setup-java' action
       # this prevents the local repo/cache from growing during the lifetime of our self hosted runners
-      - name: 🧹 Clean local maven repo
+      - name: "🧹 Clean: 🗄️ local maven repo"
         id: clean-maven-repo
         uses: dsb-norge/github-actions/ci-cd/clear-local-maven-repo@v2
+
+      # we have enabled caching with the 'actions/setup-node' action
+      # this prevents the local repo/cache from growing during the lifetime of our self hosted runners
+      - name: "🧹 Clean: 📚 local npm cache"
+        id: clean-npm-cache
+        uses: dsb-norge/github-actions/ci-cd/clear-local-npm-cache@v2
 
       - name: ⬇ Checkout working branch
         id: checkout

--- a/ci-cd/clear-local-npm-cache/action.yml
+++ b/ci-cd/clear-local-npm-cache/action.yml
@@ -1,0 +1,44 @@
+name: "Delete and re-create the local npm cache directory"
+description: |
+  This action deletes the directory returned by running `npm config get cache` if it exists.
+  Afterwards the directory is created as an empty directory.
+author: "Peder Schmedling"
+runs:
+  using: "composite"
+  steps:
+    - id: check-prereqs
+      shell: bash
+      run: |
+        # Make sure npm is available
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        start-group "check prerequisite: npm binary"
+        if ! command -v npm --version &>/dev/null; then
+          log-error "npm is not available on path, please install using the 'setup-node' action!"
+          exit 1
+        else
+          log-info "using $(npm --version)"
+        fi
+        end-group
+    - id: locate-cache
+      shell: bash
+      run: |
+        # check for existing cache directory
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        # hardcoded path to repo
+        LOCAL_CACHE_PATH="$(npm config get cache)"
+        set-output 'cache-dir-path' "${LOCAL_CACHE_PATH}"
+
+        log-info "Looking for directory '${LOCAL_CACHE_PATH}'"
+        if [ -d "${LOCAL_CACHE_PATH}" ]; then
+          log-info "the local npm cache directory exists."
+        else
+          log-info "the local npm cache  directory does not exist."
+        fi
+    - id: recreate
+      uses: dsb-norge/github-actions/directory-recreate@v2
+      with:
+        directory: ${{ steps.locate-cache.outputs.cache-dir-path }}

--- a/ci-cd/clear-local-npm-cache/helpers.sh
+++ b/ci-cd/clear-local-npm-cache/helpers.sh
@@ -1,0 +1,40 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name="$(basename "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)")"
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+function set-output { echo "${1}=${2}" >>$GITHUB_OUTPUT; }
+function set-multiline-output {
+  local outputName outputValue delimiter
+  outputName="${1}"
+  outputValue="${2}"
+  delimiter=$(echo $RANDOM | md5sum | head -c 20)
+  echo "${outputName}<<\"${delimiter}\"" >>$GITHUB_OUTPUT
+  echo "${outputValue}" >>$GITHUB_OUTPUT
+  echo "\"${delimiter}\"" >>$GITHUB_OUTPUT
+}
+function ws-path {
+  local inPath
+  inPath="${1}"
+  realpath --relative-to="${GITHUB_WORKSPACE}" "${inPath}"
+}
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."
+
+if [ -f "${GITHUB_ACTION_PATH}/helpers_additional.sh" ]; then
+  source "${GITHUB_ACTION_PATH}/helpers_additional.sh"
+fi


### PR DESCRIPTION
# changes
- feat: workflows: empty the local npm cache before builds
- chore(default ci/cd): do not wipe maven repo before deploy to static
- fix(default ci/cd): empty the local maven repo before builds