### PR TITLE
fix: align fast-xml-parser Deno import with package.json (HOTFIX)

### DIFF
--- a/ci-cd/common/deps.ts
+++ b/ci-cd/common/deps.ts
@@ -13,7 +13,7 @@ export function setGithub(newGithub: unknown) {
 export { exists } from 'jsr:@std/fs@1.0.15/exists'
 export { basename, dirname, isAbsolute, join, relative, resolve } from 'jsr:@std/path@1.0.8'
 export { parse as parseYaml, stringify as stringifyYaml } from 'jsr:@std/yaml@1.0.5'
-export { XMLParser as parseXML } from 'npm:fast-xml-parser@5.0.9'
+export { XMLParser as parseXML } from 'npm:fast-xml-parser@5.8.0'
 export { crypto } from 'jsr:@std/crypto@1.0.4'
 export { ensureDir, expandGlob } from 'jsr:@std/fs@1.0.15'
 export { encodeHex } from 'jsr:@std/encoding@1.0.8/hex'

--- a/ci-cd/deno.lock
+++ b/ci-cd/deno.lock
@@ -31,7 +31,7 @@
     "jsr:@std/yaml@1.0.5": "1.0.5",
     "npm:@actions/core@1.11.1": "1.11.1",
     "npm:@actions/github@6.0.0": "6.0.0_@octokit+core@5.2.1",
-    "npm:fast-xml-parser@5.0.9": "5.0.9"
+    "npm:fast-xml-parser@5.8.0": "5.8.0"
   },
   "jsr": {
     "@std/assert@1.0.0-rc.2": {
@@ -158,6 +158,9 @@
     "@fastify/busboy@2.1.1": {
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
     },
+    "@nodable/entities@2.1.0": {
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="
+    },
     "@octokit/auth-token@4.0.0": {
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
     },
@@ -243,10 +246,21 @@
     "deprecation@2.3.1": {
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
-    "fast-xml-parser@5.0.9": {
-      "integrity": "sha512-2mBwCiuW3ycKQQ6SOesSB8WeF+fIGb6I/GG5vU5/XEptwFFhp9PE8b9O7fbs2dpq9fXn4ULR3UsfydNUCntf5A==",
+    "fast-xml-builder@1.2.0": {
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dependencies": [
-        "strnum"
+        "path-expression-matcher",
+        "xml-naming"
+      ]
+    },
+    "fast-xml-parser@5.8.0": {
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "dependencies": [
+        "@nodable/entities",
+        "fast-xml-builder",
+        "path-expression-matcher",
+        "strnum",
+        "xml-naming"
       ],
       "bin": true
     },
@@ -256,8 +270,11 @@
         "wrappy"
       ]
     },
-    "strnum@2.0.5": {
-      "integrity": "sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q=="
+    "path-expression-matcher@1.5.0": {
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="
+    },
+    "strnum@2.3.0": {
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="
     },
     "tunnel@0.0.6": {
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
@@ -273,6 +290,9 @@
     },
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "xml-naming@0.1.0": {
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="
     }
   },
   "workspace": {
@@ -280,7 +300,7 @@
       "dependencies": [
         "npm:@actions/core@1.11.1",
         "npm:@actions/github@6.0.0",
-        "npm:fast-xml-parser@5.0.9"
+        "npm:fast-xml-parser@5.8.0"
       ]
     }
   }


### PR DESCRIPTION
## ⚠️ Production-breaking — please fast-track

PR #100 bumped \`fast-xml-parser\` to 5.8.0 in \`ci-cd/package.json\` (security fix), but Renovate cannot see the explicit \`@5.0.9\` pin inside \`ci-cd/common/deps.ts\` — Deno-style \`npm:\` imports in \`.ts\` files aren't covered by Renovate's npm manager.

Result on every consumer of \`@v4\`:

\`\`\`
error: Could not find a matching package for 'npm:fast-xml-parser@5.0.9' in the node_modules directory.
    at file:///.../ci-cd/common/deps.ts:16:39
##[error]Process completed with exit code 1.
\`\`\`

Example failing run: dsb-norge/milo#237 (run 26276890209).

## Fix

- Update Deno import in \`ci-cd/common/deps.ts\`: \`@5.0.9\` → \`@5.8.0\`
- Regenerate \`ci-cd/deno.lock\` (now consistent with package.json)

## Verification

- \`deno task test\` from \`ci-cd/\`: ✅ **55 passed | 0 failed** (no API changes between 5.0.9 → 5.8.0 in the surface we use)

## After merge

Cut \`v4.11\` and force-move \`v4\` to unblock all consumer repos.

## Follow-up (separate)

Org-wide \`dsb-norge/.github:renovate-config\` should add a \`customManagers\` regex rule for \`npm:<dep>@<ver>\` in \`.ts\` files so this class of mismatch can't repeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)