### PR TITLE
feat: configurable runs-on across all reusable CI/CD workflows (default = current self-hosted)

### DIFF
--- a/.github/workflows/ci-cd-build-deploy-maven-lib.yml
+++ b/.github/workflows/ci-cd-build-deploy-maven-lib.yml
@@ -37,15 +37,16 @@ on:
       runs-on:
         type: string
         required: false
-        # Default IS the historical hardcoded value, so callers that don't set this are unaffected.
-        # Enables gradual, per-repo migration to GitHub-hosted runners with one-line rollback.
-        default: '["self-hosted", "dsb-builder", "linux", "x64"]'
+        # Empty (default) = the historical self-hosted pool, kept inside the workflow as a fromJSON
+        # fallback so callers that don't set this are unaffected. Any non-empty value is used as-is
+        # (like the terraform actions), so opting in is just a plain string — no JSON.
+        default: ""
         description: |
-          Runner to run jobs on, as a JSON array string (decoded with fromJSON). Use a one-element
-          array for a single GitHub-hosted larger runner (matched by name), same shape as the default:
-            self-hosted pool (default): '["self-hosted", "dsb-builder", "linux", "x64"]'
-            GitHub-hosted larger runner: '["builder-app-platform-ghr-ubuntu-large"]'
-          Applies to all jobs except the final 'ci-cd-conclusion' gate (always ubuntu-latest).
+          Global runner for all jobs, as a plain string: a single GitHub-hosted larger runner name
+          (matched by name), e.g. 'builder-app-platform-ghr-ubuntu-large'. Empty (default) uses the
+          self-hosted pool [self-hosted, dsb-builder, linux, x64]. Can be overridden per application
+          with a 'runs-on' field on an entry in 'apps'. The final 'ci-cd-conclusion' gate always
+          runs on ubuntu-latest.
       # below are repo-specific settings, not app specific and thus does not belong in 'apps'
       # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
       # sane defaults are defined but can be overridden pr. repo
@@ -77,7 +78,7 @@ on:
 jobs:
   create-matrix:
     name: Create build matrix
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ inputs.runs-on || fromJSON('["self-hosted", "dsb-builder", "linux", "x64"]') }}
     defaults:
       run:
         shell: bash
@@ -103,7 +104,8 @@ jobs:
   build-and-deploy:
     name: Build and deploy to artifact repo
     needs: create-matrix
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    # per-app 'runs-on' wins, else the global input, else the self-hosted default
+    runs-on: ${{ matrix.app-vars.runs-on || inputs.runs-on || fromJSON('["self-hosted", "dsb-builder", "linux", "x64"]') }}
     strategy:
       matrix: ${{ fromJSON(needs.create-matrix.outputs.app-vars-matrix) }}
     defaults:
@@ -225,7 +227,7 @@ jobs:
       &&
       ( github.event_name != 'pull_request' || github.event.action == 'closed' )
     needs: [create-matrix, build-and-deploy]
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ inputs.runs-on || fromJSON('["self-hosted", "dsb-builder", "linux", "x64"]') }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-cd-build-deploy-maven-lib.yml
+++ b/.github/workflows/ci-cd-build-deploy-maven-lib.yml
@@ -34,6 +34,18 @@ on:
             - application-type        - string, always 'maven-library'
           For optional fields see possible inputs to the create-build-envs action.
         required: true
+      runs-on:
+        type: string
+        required: false
+        # Default IS the historical hardcoded value, so callers that don't set this are unaffected.
+        # Enables gradual, per-repo migration to GitHub-hosted runners with one-line rollback.
+        default: '["self-hosted", "dsb-builder", "linux", "x64"]'
+        description: |
+          Runner to run jobs on, as a JSON array string (decoded with fromJSON). Use a one-element
+          array for a single GitHub-hosted larger runner (matched by name), same shape as the default:
+            self-hosted pool (default): '["self-hosted", "dsb-builder", "linux", "x64"]'
+            GitHub-hosted larger runner: '["builder-app-platform-ghr-ubuntu-large"]'
+          Applies to all jobs except the final 'ci-cd-conclusion' gate (always ubuntu-latest).
       # below are repo-specific settings, not app specific and thus does not belong in 'apps'
       # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
       # sane defaults are defined but can be overridden pr. repo
@@ -65,7 +77,7 @@ on:
 jobs:
   create-matrix:
     name: Create build matrix
-    runs-on: [self-hosted, dsb-builder, linux, x64]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     defaults:
       run:
         shell: bash
@@ -91,7 +103,7 @@ jobs:
   build-and-deploy:
     name: Build and deploy to artifact repo
     needs: create-matrix
-    runs-on: [self-hosted, dsb-builder, linux, x64]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     strategy:
       matrix: ${{ fromJSON(needs.create-matrix.outputs.app-vars-matrix) }}
     defaults:
@@ -213,7 +225,7 @@ jobs:
       &&
       ( github.event_name != 'pull_request' || github.event.action == 'closed' )
     needs: [create-matrix, build-and-deploy]
-    runs-on: [self-hosted, dsb-builder, linux, x64]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -47,10 +47,13 @@ on:
         # Enables gradual, per-repo migration to GitHub-hosted runners with one-line rollback.
         default: '["self-hosted", "dsb-builder", "linux", "x64"]'
         description: |
-          Runner to run jobs on, as a JSON-encoded string (decoded with fromJSON).
-          Either a label array, e.g. '["self-hosted", "dsb-builder", "linux", "x64"]' (default),
-          or a single GitHub-hosted runner name, e.g. '"builder-app-platform-ghr-ubuntu-large"'.
-          Applies to all jobs except the final 'ci-cd-conclusion' gate (always ubuntu-latest).
+          Runner to run jobs on, as a JSON array string (decoded with fromJSON). Use a one-element
+          array for a single GitHub-hosted larger runner (matched by name), same shape as the default:
+            self-hosted pool (default): '["self-hosted", "dsb-builder", "linux", "x64"]'
+            GitHub-hosted larger runner: '["builder-app-platform-ghr-ubuntu-large"]'
+          (A bare JSON string like '"builder-app-platform-ghr-ubuntu-large"' also works, but the array
+          form is preferred for consistency.) Applies to all jobs except the final 'ci-cd-conclusion'
+          gate (always ubuntu-latest).
       # below are repo-specific settings, not app specific and thus does not belong in 'apps'
       # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
       # sane defaults are defined but can be overridden pr. repo

--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -43,17 +43,16 @@ on:
       runs-on:
         type: string
         required: false
-        # Default IS the historical hardcoded value, so callers that don't set this are unaffected.
-        # Enables gradual, per-repo migration to GitHub-hosted runners with one-line rollback.
-        default: '["self-hosted", "dsb-builder", "linux", "x64"]'
+        # Empty (default) = the historical self-hosted pool, kept inside the workflow as a fromJSON
+        # fallback so callers that don't set this are unaffected. Any non-empty value is used as-is
+        # (like the terraform actions), so opting in is just a plain string — no JSON.
+        default: ""
         description: |
-          Runner to run jobs on, as a JSON array string (decoded with fromJSON). Use a one-element
-          array for a single GitHub-hosted larger runner (matched by name), same shape as the default:
-            self-hosted pool (default): '["self-hosted", "dsb-builder", "linux", "x64"]'
-            GitHub-hosted larger runner: '["builder-app-platform-ghr-ubuntu-large"]'
-          (A bare JSON string like '"builder-app-platform-ghr-ubuntu-large"' also works, but the array
-          form is preferred for consistency.) Applies to all jobs except the final 'ci-cd-conclusion'
-          gate (always ubuntu-latest).
+          Global runner for all jobs, as a plain string: a single GitHub-hosted larger runner name
+          (matched by name), e.g. 'builder-app-platform-ghr-ubuntu-large'. Empty (default) uses the
+          self-hosted pool [self-hosted, dsb-builder, linux, x64]. Can be overridden per application
+          with a 'runs-on' field on an entry in 'apps'. The final 'ci-cd-conclusion' gate always
+          runs on ubuntu-latest.
       # below are repo-specific settings, not app specific and thus does not belong in 'apps'
       # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
       # sane defaults are defined but can be overridden pr. repo
@@ -85,7 +84,7 @@ on:
 jobs:
   check-docker-disk-space:
     name: Check Docker Disk Space & Prune if Needed
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ inputs.runs-on || fromJSON('["self-hosted", "dsb-builder", "linux", "x64"]') }}
     defaults:
       run:
         shell: bash
@@ -105,7 +104,7 @@ jobs:
   create-matrix:
     name: Create build matrix
     needs: check-docker-disk-space
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ inputs.runs-on || fromJSON('["self-hosted", "dsb-builder", "linux", "x64"]') }}
     defaults:
       run:
         shell: bash
@@ -147,7 +146,8 @@ jobs:
   build-deploy:
     name: Build and deploy
     needs: create-matrix
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    # per-app 'runs-on' wins, else the global input, else the self-hosted default
+    runs-on: ${{ matrix.app-vars.runs-on || inputs.runs-on || fromJSON('["self-hosted", "dsb-builder", "linux", "x64"]') }}
     strategy:
       matrix: ${{ fromJSON(needs.create-matrix.outputs.app-vars-matrix) }}
       fail-fast: false
@@ -482,7 +482,7 @@ jobs:
     if: |
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' )
     needs: [create-matrix, build-deploy]
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ inputs.runs-on || fromJSON('["self-hosted", "dsb-builder", "linux", "x64"]') }}
     defaults:
       run:
         shell: bash
@@ -560,7 +560,7 @@ jobs:
       &&
       ( github.event_name != 'pull_request' || github.event.action == 'closed' )
     needs: [create-matrix, build-deploy]
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ inputs.runs-on || fromJSON('["self-hosted", "dsb-builder", "linux", "x64"]') }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-cd-default.yml
+++ b/.github/workflows/ci-cd-default.yml
@@ -40,6 +40,17 @@ on:
             - application-name        - string
           For optional fields see possible inputs to the create-build-envs action.
         required: true
+      runs-on:
+        type: string
+        required: false
+        # Default IS the historical hardcoded value, so callers that don't set this are unaffected.
+        # Enables gradual, per-repo migration to GitHub-hosted runners with one-line rollback.
+        default: '["self-hosted", "dsb-builder", "linux", "x64"]'
+        description: |
+          Runner to run jobs on, as a JSON-encoded string (decoded with fromJSON).
+          Either a label array, e.g. '["self-hosted", "dsb-builder", "linux", "x64"]' (default),
+          or a single GitHub-hosted runner name, e.g. '"builder-app-platform-ghr-ubuntu-large"'.
+          Applies to all jobs except the final 'ci-cd-conclusion' gate (always ubuntu-latest).
       # below are repo-specific settings, not app specific and thus does not belong in 'apps'
       # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
       # sane defaults are defined but can be overridden pr. repo
@@ -71,7 +82,7 @@ on:
 jobs:
   check-docker-disk-space:
     name: Check Docker Disk Space & Prune if Needed
-    runs-on: [self-hosted, dsb-builder, linux, x64]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     defaults:
       run:
         shell: bash
@@ -91,7 +102,7 @@ jobs:
   create-matrix:
     name: Create build matrix
     needs: check-docker-disk-space
-    runs-on: [self-hosted, dsb-builder, linux, x64]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     defaults:
       run:
         shell: bash
@@ -133,7 +144,7 @@ jobs:
   build-deploy:
     name: Build and deploy
     needs: create-matrix
-    runs-on: [self-hosted, dsb-builder, linux, x64]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     strategy:
       matrix: ${{ fromJSON(needs.create-matrix.outputs.app-vars-matrix) }}
       fail-fast: false
@@ -468,7 +479,7 @@ jobs:
     if: |
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' )
     needs: [create-matrix, build-deploy]
-    runs-on: [self-hosted, dsb-builder, linux, x64]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     defaults:
       run:
         shell: bash
@@ -546,7 +557,7 @@ jobs:
       &&
       ( github.event_name != 'pull_request' || github.event.action == 'closed' )
     needs: [create-matrix, build-deploy]
-    runs-on: [self-hosted, dsb-builder, linux, x64]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/maven-artifacts-pruner.yml
+++ b/.github/workflows/maven-artifacts-pruner.yml
@@ -9,15 +9,15 @@ on:
       runs-on:
         type: string
         required: false
-        # Default IS the historical hardcoded value, so callers that don't set this are unaffected.
-        # Enables gradual, per-repo migration to GitHub-hosted runners with one-line rollback.
-        default: '["self-hosted", "dsb-builder", "linux", "x64"]'
+        # Empty (default) = the historical self-hosted pool, kept inside the workflow as a fromJSON
+        # fallback so callers that don't set this are unaffected. Any non-empty value is used as-is
+        # (like the terraform actions), so opting in is just a plain string — no JSON.
+        default: ""
         description: |
-          Runner to run jobs on, as a JSON array string (decoded with fromJSON). Use a one-element
-          array for a single GitHub-hosted larger runner (matched by name), same shape as the default:
-            self-hosted pool (default): '["self-hosted", "dsb-builder", "linux", "x64"]'
-            GitHub-hosted larger runner: '["builder-app-platform-ghr-ubuntu-large"]'
-          Applies to the prune job; the 'ci-cd-conclusion' gate always runs on ubuntu-latest.
+          Runner for the prune job, as a plain string: a single GitHub-hosted larger runner name
+          (matched by name), e.g. 'builder-app-platform-ghr-ubuntu-large'. Empty (default) uses the
+          self-hosted pool [self-hosted, dsb-builder, linux, x64]. The 'ci-cd-conclusion' gate
+          always runs on ubuntu-latest.
       # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
       # sane defaults are defined but can be overridden pr. repo
       release-prune-keep-min-count:
@@ -57,7 +57,7 @@ jobs:
   prune-maven-artifacts:
     name: Prune maven artifacts
     # This job handles pruning of maven artifacts published in the calling repo
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ inputs.runs-on || fromJSON('["self-hosted", "dsb-builder", "linux", "x64"]') }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/maven-artifacts-pruner.yml
+++ b/.github/workflows/maven-artifacts-pruner.yml
@@ -6,6 +6,18 @@ name: "DSB retention policy for maven artifacts in GitHub Packages"
 on:
   workflow_call:
     inputs:
+      runs-on:
+        type: string
+        required: false
+        # Default IS the historical hardcoded value, so callers that don't set this are unaffected.
+        # Enables gradual, per-repo migration to GitHub-hosted runners with one-line rollback.
+        default: '["self-hosted", "dsb-builder", "linux", "x64"]'
+        description: |
+          Runner to run jobs on, as a JSON array string (decoded with fromJSON). Use a one-element
+          array for a single GitHub-hosted larger runner (matched by name), same shape as the default:
+            self-hosted pool (default): '["self-hosted", "dsb-builder", "linux", "x64"]'
+            GitHub-hosted larger runner: '["builder-app-platform-ghr-ubuntu-large"]'
+          Applies to the prune job; the 'ci-cd-conclusion' gate always runs on ubuntu-latest.
       # for explanation of maven artifact pruning configuration see inputs of 'ci-cd/prune-maven-artifacts-in-repo/action.yml'
       # sane defaults are defined but can be overridden pr. repo
       release-prune-keep-min-count:
@@ -45,7 +57,7 @@ jobs:
   prune-maven-artifacts:
     name: Prune maven artifacts
     # This job handles pruning of maven artifacts published in the calling repo
-    runs-on: [self-hosted, dsb-builder, linux, x64]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## What

Adds a `runs-on` input to **all three** reusable workflows so calling repos can target **GitHub-hosted larger runners** instead of the self-hosted `dsb-builder` pool — the **Phase A** retargeting mechanism for the [GitHub-hosted runner migration](https://github.com/dsb-infra/azure-terraform-ikt-app-platform-common-config-legacy/blob/docs/github-runner-phase2-provisioning/docs/github-hosted-runners-implementation-plan.md#retargeting-mechanism--parameterize-runs-on-in-the-default-cicd-workflow):

- `ci-cd-default.yml` (app build/deploy)
- `maven-artifacts-pruner.yml` (called by app repos' prune workflows, incl. test-application)
- `ci-cd-build-deploy-maven-lib.yml` (maven-library repos)

So a repo can move its **whole** pipeline, not just the build.

- **Default is the current hardcoded value** `["self-hosted", "dsb-builder", "linux", "x64"]` → existing callers unaffected.
- **JSON-array string + `fromJSON()`**, so one input expresses both a self-hosted label array and a single GitHub-hosted runner name. Opt in: `runs-on: '["builder-app-platform-ghr-ubuntu-large"]'`; roll back: remove it.
- `ci-cd-conclusion` gates stay on `ubuntu-latest`. No hardcoded self-hosted set remains in any reusable workflow.

## Validated end-to-end

[test-application PR #697](https://github.com/dsb-norge/test-application/pull/697) ran **fully green** on the GitHub-hosted custom-image runner (`builder-app-platform-ghr-ubuntu-large`, image `builder-app-platform-ghr-image` v1.1: deno/typst/uv/helm4): Maven build → ACR push → `helm upgrade` deploy to private DEV AKS → ephemeral PR env.

## Pre-release

Movable dev tag **`runs-on-input`** points at this branch for piloting. After review, release as a new minor `v4.x` (move `v4`) per the dev-and-release guide; callers then consume the stable tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)